### PR TITLE
BAU: Fix app local port

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ Run:
 
 A local dev server will be created on
 
-    http://localhost:5028/
+    http://localhost:5000
 
-Flask environment variables are configurable in .flaskenv
+Flask environment variables are configurable in `.flaskenv`
 
 # Configuration
 


### PR DESCRIPTION
This reflects the default port used when running `flask run`.