### PR TITLE
magic_link template added for user information

### DIFF
--- a/frontend/magic_links/templates/magic_link.html
+++ b/frontend/magic_links/templates/magic_link.html
@@ -1,0 +1,14 @@
+{%- from "govuk_frontend_jinja/components/input/macro.html" import govukInput -%}
+{%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
+{%- from "govuk_frontend_jinja/components/panel/macro.html" import govukPanel -%}
+
+{% extends "base.html" %}
+
+{% block content %}
+
+{{ govukPanel({
+  "titleText": "We've emailed you a link to sign in",
+  "html": "Check your email and follow the link to continue your application"
+}) }}
+
+{% endblock %}

--- a/frontend/magic_links/templates/magic_link.html
+++ b/frontend/magic_links/templates/magic_link.html
@@ -1,5 +1,3 @@
-{%- from "govuk_frontend_jinja/components/input/macro.html" import govukInput -%}
-{%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 {%- from "govuk_frontend_jinja/components/panel/macro.html" import govukPanel -%}
 
 {% extends "base.html" %}


### PR DESCRIPTION
A very simple template was added with instructions to send it to the user once the sign-in link was mailed to the user. 