### PR TITLE
BAU: default session cookie value

### DIFF
--- a/config/environments/default.py
+++ b/config/environments/default.py
@@ -6,7 +6,7 @@ from os import path
 class Config(object):
     #  Application Config
     SECRET_KEY = environ.get("SECRET_KEY")
-    SESSION_COOKIE_NAME = environ.get("SESSION_COOKIE_NAME")
+    SESSION_COOKIE_NAME = environ.get("SESSION_COOKIE_NAME", "session_cookie")
     FLASK_ROOT = path.dirname(
         path.dirname(path.dirname(path.realpath(__file__)))
     )


### PR DESCRIPTION
Previously the session cookie value was not set in the test config. This caused an exception when attempting to create a session on the test environment. The same error did not occur on dev because we set the value on that environment here: https://github.com/communitiesuk/funding-service-design-authenticator/blob/fae3d04fb5434d450dd2481e2265931c28b3d3f0/config/environments/dev.py#L13

