### PR TITLE
BAU: Use variable substitution to inject secrets

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -13,6 +13,12 @@ applications:
     MAGIC_LINK_REDIRECT_URL: https://funding-service-design-frontend-dev.london.cloudapps.digital/account/{account_id}
     FLASK_ENV: dev
     FLASK_DEBUG: 1
+    RSA256_PRIVATE_KEY: ((RSA256_PRIVATE_KEY))
+    RSA256_PUBLIC_KEY: ((RSA256_PUBLIC_KEY))
+    AZURE_AD_CLIENT_SECRET: ((AZURE_AD_CLIENT_SECRET))
+    SECRET_KEY: ((SECRET_KEY))
+    SESSION_COOKIE_NAME: ((SESSION_COOKIE_NAME))
+
   services: # eg. Redis
     - funding-service-magic-links-dev
 
@@ -28,5 +34,10 @@ applications:
     NOTIFICATION_SERVICE_HOST: http://funding-service-design-notification-test.apps.internal:8080
     MAGIC_LINK_REDIRECT_URL: https://funding-service-design-frontend-test.london.cloudapps.digital/account/{account_id}
     FLASK_ENV: test
+    RSA256_PRIVATE_KEY: ((RSA256_PRIVATE_KEY))
+    RSA256_PUBLIC_KEY: ((RSA256_PUBLIC_KEY))
+    AZURE_AD_CLIENT_SECRET: ((AZURE_AD_CLIENT_SECRET))
+    SECRET_KEY: ((SECRET_KEY))
+    SESSION_COOKIE_NAME: ((SESSION_COOKIE_NAME))
   services: # eg. Redis
     - funding-service-magic-links-test


### PR DESCRIPTION
Previously we were setting secrets using `--var` but they were not reaching the application as they need to be explicitly set using variable substitution
See also https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#variable-substitution
and https://github.com/cloudfoundry/cli/issues/1012#issuecomment-625404004