### PR TITLE
FS-1060: fix multiline secrets on test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,7 @@ jobs:
           cf_space:    ${{secrets.CF_SPACE }}
           cf_username: ${{secrets.CF_USER}}
           cf_password: ${{secrets.CF_PASSWORD}}
-          command: push funding-service-design-authenticator-dev --var RSA256_PRIVATE_KEY="${{secrets.RSA256_PRIVATE_KEY}}" --var RSA256_PUBLIC_KEY="${{secrets.RSA256_PUBLIC_KEY}}" --var AZURE_AD_CLIENT_SECRET="${{secrets.AZURE_AD_CLIENT_SECRET}}" --var SECRET_KEY="${{secrets.SECRET_KEY}}" --var SESSION_COOKIE_NAME="${{secrets.SESSION_COOKIE_NAME}}"
+          command: push funding-service-design-authenticator-dev -f manifest-dev.yml
       - name: Apply network policy for notification service
         uses: citizen-of-planet-earth/cf-cli-action@v2
         with:
@@ -128,7 +128,7 @@ jobs:
           cf_space:    ${{secrets.CF_SPACE }}
           cf_username: ${{secrets.CF_USER}}
           cf_password: ${{secrets.CF_PASSWORD}}
-          command: push funding-service-design-authenticator-test --var RSA256_PRIVATE_KEY="${{secrets.RSA256_PRIVATE_KEY}}" --var RSA256_PUBLIC_KEY="${{secrets.RSA256_PUBLIC_KEY}}" --var AZURE_AD_CLIENT_SECRET="${{secrets.AZURE_AD_CLIENT_SECRET}}" --var SECRET_KEY="${{secrets.SECRET_KEY}}" --var SESSION_COOKIE_NAME="${{secrets.SESSION_COOKIE_NAME}}"
+          command: push funding-service-design-authenticator-test -f manifest-test.yml --var RSA256_PRIVATE_KEY_BASE64="${{secrets.RSA256_PRIVATE_KEY_BASE64}}" --var RSA256_PUBLIC_KEY_BASE64="${{secrets.RSA256_PUBLIC_KEY_BASE64}}"  --var RSA256_PUBLIC_KEY="${{secrets.RSA256_PUBLIC_KEY}}" --var RSA256_PRIVATE_KEY="${{secrets.RSA256_PRIVATE_KEY}}" --var RSA256_PUBLIC_KEY="${{secrets.RSA256_PUBLIC_KEY}}" --var AZURE_AD_CLIENT_SECRET="${{secrets.AZURE_AD_CLIENT_SECRET}}" --var SECRET_KEY="${{secrets.SECRET_KEY}}" --var SESSION_COOKIE_NAME="${{secrets.SESSION_COOKIE_NAME}}"
       - name: Apply network policy for notification service
         uses: citizen-of-planet-earth/cf-cli-action@v2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,7 +128,7 @@ jobs:
           cf_space:    ${{secrets.CF_SPACE }}
           cf_username: ${{secrets.CF_USER}}
           cf_password: ${{secrets.CF_PASSWORD}}
-          command: push funding-service-design-authenticator-test -f manifest-test.yml --var RSA256_PRIVATE_KEY_BASE64="${{secrets.RSA256_PRIVATE_KEY_BASE64}}" --var RSA256_PUBLIC_KEY_BASE64="${{secrets.RSA256_PUBLIC_KEY_BASE64}}"  --var RSA256_PUBLIC_KEY="${{secrets.RSA256_PUBLIC_KEY}}" --var RSA256_PRIVATE_KEY="${{secrets.RSA256_PRIVATE_KEY}}" --var RSA256_PUBLIC_KEY="${{secrets.RSA256_PUBLIC_KEY}}" --var AZURE_AD_CLIENT_SECRET="${{secrets.AZURE_AD_CLIENT_SECRET}}" --var SECRET_KEY="${{secrets.SECRET_KEY}}" --var SESSION_COOKIE_NAME="${{secrets.SESSION_COOKIE_NAME}}"
+          command: push funding-service-design-authenticator-test -f manifest-test.yml --var RSA256_PRIVATE_KEY_BASE64="${{secrets.RSA256_PRIVATE_KEY_BASE64}}" --var RSA256_PUBLIC_KEY_BASE64="${{secrets.RSA256_PUBLIC_KEY_BASE64}}"  --var AZURE_AD_CLIENT_SECRET="${{secrets.AZURE_AD_CLIENT_SECRET}}" --var SECRET_KEY="${{secrets.SECRET_KEY}}" --var SESSION_COOKIE_NAME="${{secrets.SESSION_COOKIE_NAME}}"
       - name: Apply network policy for notification service
         uses: citizen-of-planet-earth/cf-cli-action@v2
         with:

--- a/config/environments/test.py
+++ b/config/environments/test.py
@@ -4,6 +4,7 @@ from os import environ
 import redis
 from config.environments.default import Config
 from config.utils import VcapServices
+import base64
 
 
 class TestConfig(Config):
@@ -21,3 +22,5 @@ class TestConfig(Config):
     REDIS_MLINKS_URL = REDIS_INSTANCE_URI + "/0"
     REDIS_SESSIONS_URL = REDIS_INSTANCE_URI + "/1"
     SESSION_REDIS = redis.from_url(REDIS_SESSIONS_URL)
+    RSA256_PRIVATE_KEY = base64.b64decode(environ.get("RSA256_PRIVATE_KEY_BASE64")).decode()
+    RSA256_PUBLIC_KEY = base64.b64decode(environ.get("RSA256_PUBLIC_KEY_BASE64")).decode()

--- a/manifest-dev.yml
+++ b/manifest-dev.yml
@@ -1,0 +1,18 @@
+---
+applications:
+- name: funding-service-design-authenticator-dev
+  memory: 64M
+  buildpacks:
+  - https://github.com/cloudfoundry/python-buildpack.git
+  command: flask run --host 0.0.0.0 --port 8080
+  env:
+    AUTHENTICATOR_HOST: https://funding-service-design-authenticator-dev.london.cloudapps.digital
+    ACCOUNT_STORE_API_HOST: https://funding-service-design-account-store-dev.london.cloudapps.digital
+    APPLICATION_STORE_API_HOST: https://funding-service-design-application-store-dev.london.cloudapps.digital
+    NOTIFICATION_SERVICE_HOST: http://funding-service-design-notification-dev.apps.internal:8080
+    MAGIC_LINK_REDIRECT_URL: https://funding-service-design-frontend-dev.london.cloudapps.digital/account/{account_id}
+    FLASK_ENV: dev
+    FLASK_DEBUG: 1
+
+  services: # eg. Redis
+    - funding-service-magic-links-dev

--- a/manifest-test.yml
+++ b/manifest-test.yml
@@ -1,0 +1,21 @@
+---
+applications:
+- name: funding-service-design-authenticator-test
+  memory: 64M
+  buildpacks:
+  - https://github.com/cloudfoundry/python-buildpack.git
+  command: flask run --host 0.0.0.0 --port 8080
+  env:
+    AUTHENTICATOR_HOST: https://funding-service-design-authenticator-test.london.cloudapps.digital
+    ACCOUNT_STORE_API_HOST: https://funding-service-design-account-store-test.london.cloudapps.digital
+    APPLICATION_STORE_API_HOST: https://funding-service-design-application-store-test.london.cloudapps.digital
+    NOTIFICATION_SERVICE_HOST: http://funding-service-design-notification-test.apps.internal:8080
+    MAGIC_LINK_REDIRECT_URL: https://funding-service-design-frontend-test.london.cloudapps.digital/account/{account_id}
+    FLASK_ENV: test
+    RSA256_PUBLIC_KEY_BASE64: ((RSA256_PUBLIC_KEY_BASE64))
+    RSA256_PRIVATE_KEY_BASE64: ((RSA256_PRIVATE_KEY_BASE64))
+    AZURE_AD_CLIENT_SECRET: ((AZURE_AD_CLIENT_SECRET))
+    SECRET_KEY: ((SECRET_KEY))
+    SESSION_COOKIE_NAME: ((SESSION_COOKIE_NAME))
+  services: # eg. Redis
+    - funding-service-magic-links-test


### PR DESCRIPTION
Following https://github.com/communitiesuk/funding-service-design-authenticator/pull/13 magic link creation was still failing on Test, as the RSA keys were not being parsed correctly as new-lines were getting stripped during the deployment process.

This adds a workaround encoding the secrets as base-64 to represent them as a string without line breaks. 

It also separates out the manifests to allow dev and test environments to have different environment variables.

You can verify this is working by creating a magic link on test e.g. from https://funding-service-design-authenticator-test.london.cloudapps.digital/service/magic-links/new?fund_id=funding-service-design&round_id=spring