### PR TITLE
BAU: limit test deploys to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,6 +104,7 @@ jobs:
           allow_issue_writing: False
 
   deploy_test:
+    if: github.ref == 'refs/heads/main'
     needs: security
     runs-on: ubuntu-latest
     environment: test


### PR DESCRIPTION
Same change as https://github.com/communitiesuk/funding-design-service-workflows/pull/6 as this repo has forked the workflkow