### PR TITLE
FS-1053: use correct email value in error case

### DIFF
--- a/frontend/magic_links/templates/email.html
+++ b/frontend/magic_links/templates/email.html
@@ -31,7 +31,7 @@
                 },
                 'id': form.email.id,
                 'name': form.email.name,
-                'value': form.email.value,
+                'value': form.email.data,
                 "type": "email",
                 "autocomplete": "email",
                 "spellcheck": false,


### PR DESCRIPTION
Previously we were using an incorrect value when reading the form data back after an error. This fixes the value so now the data is retained if there is an error in the form submission. 
**Screenshot**
![Screenshot 2022-06-15 at 13 43 36](https://user-images.githubusercontent.com/1764158/173830097-fb03261e-acef-41d1-94aa-371e8a88fe5d.png)

