### PR TITLE
BAU: refactor error view

### DIFF
--- a/frontend/magic_links/templates/email.html
+++ b/frontend/magic_links/templates/email.html
@@ -23,7 +23,6 @@
         <h1 class="govuk-label-wrapper"><label class="govuk-label govuk-label--l" for="email">Email address</label>
         </h1>
         {{form.hidden_tag()}}
-          {% if form.email.errors %}
             {{ govukInput({
                 'label': None,
                 'hint': {
@@ -38,23 +37,8 @@
                 'classes': form.email.classes,
                 'errorMessage': {
                     'text': form.email.errors.0
-                }
+                } if form.email.errors
             }) }}
-        {% else %}
-            {{ govukInput({
-                'label': None,
-                'hint': {
-                    'text': form.email.description
-                },
-                'id': form.email.id,
-                'name': form.email.name,
-                'value': form.email.data,
-                "type": "email",
-                "autocomplete": "email",
-                "spellcheck": false,
-                'classes': form.email.classes,
-            }) }}
-        {% endif %}
         </div>
             {{ govukButton({
               "text": "Continue",


### PR DESCRIPTION
Spotted in the course of another story.

Previously we were repeating the whole input block even though only the error block differs.  Refactor to just conditionally include the error block.