### PR TITLE
BAU: Add common Talisman initialisation method and config to default.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -75,13 +75,15 @@ def create_app() -> Flask:
     # Initialise Redis Magic Links Store
     redis_mlinks.init_app(flask_app)
 
-    # Configure Talisman Security Settings
-    talisman = Talisman(
-        flask_app,
-        strict_transport_security=Config.HSTS_HEADERS,
-        force_https=Config.FORCE_HTTPS,
-        content_security_policy_nonce_in=["script-src"],
-    )
+    # # Configure Talisman Security Settings
+    # talisman = Talisman(
+    #     flask_app,
+    #     strict_transport_security=Config.HSTS_HEADERS,
+    #     force_https=Config.FORCE_HTTPS,
+    #     content_security_policy_nonce_in=["script-src"],
+    # )
+    # Configure application security with Talisman
+    talisman = Talisman(flask_app, **Config.TALISMAN_SETTINGS)
 
     # This section is needed for url_for("foo", _external=True) to
     # automatically generate http scheme when this sample is

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -119,10 +119,10 @@ class DefaultConfig(object):
     RSA256_PRIVATE_KEY = environ.get("RSA256_PRIVATE_KEY")
     RSA256_PUBLIC_KEY = environ.get("RSA256_PUBLIC_KEY")
 
-    # Security Settings (for Talisman Config)
+    # Talisman Config
     FORCE_HTTPS = True
 
-    # Content Security Policy (for Talisman Config)
+    # Content Security Policy
     SECURE_CSP = {
         "default-src": "'self'",
         "script-src": [
@@ -133,21 +133,82 @@ class DefaultConfig(object):
         "img-src": ["data:", "'self'"],
     }
 
-    # Allow inline scripts for swagger docs (for Talisman Config)
+    # Content Security Policy for Swagger (Allow inline scripts)
     SWAGGER_CSP = {
         "script-src": ["'self'", "'unsafe-inline'"],
         "style-src": ["'self'", "'unsafe-inline'"],
     }
 
-    # HTTP Strict-Transport-Security (for Talisman Config)
-    HSTS_HEADERS = {
-        "strict-transport-security": (
-            "max-age=31536000; includeSubDomains; preload"
-        ),
-        "X-Content-Type-Options": "nosniff",
-        "X-Frame-Options": "SAMEORIGIN",
-        "X-XSS-Protection": "1; mode=block",
-        "Feature_Policy": (
-            "microphone 'none'; camera 'none'; geolocation 'none'"
-        ),
+    # Security headers and other policies
+    FSD_REFERRER_POLICY = "strict-origin-when-cross-origin"
+    FSD_SESSION_COOKIE_SAMESITE = "Lax"
+    FSD_PERMISSIONS_POLICY = {"interest-cohort": "()"}
+    FSD_DOCUMENT_POLICY = {}
+    FSD_FEATURE_POLICY = {
+        "microphone": "'bob'",
+        "camera": "'none'",
+        "geolocation": "'none'",
     }
+
+    DENY = "DENY"
+    SAMEORIGIN = "SAMEORIGIN"
+    ALLOW_FROM = "ALLOW-FROM"
+    ONE_YEAR_IN_SECS = 31556926
+
+    TALISMAN_SETTINGS = {
+        "feature_policy": FSD_FEATURE_POLICY,
+        "permissions_policy": FSD_PERMISSIONS_POLICY,
+        "document_policy": FSD_DOCUMENT_POLICY,
+        "force_https": FORCE_HTTPS,
+        "force_https_permanent": False,
+        "force_file_save": False,
+        "frame_options": "SAMEORIGIN",
+        "frame_options_allow_from": None,
+        "strict_transport_security": True,
+        "strict_transport_security_preload": True,
+        "strict_transport_security_max_age": ONE_YEAR_IN_SECS,
+        "strict_transport_security_include_subdomains": True,
+        "content_security_policy": SECURE_CSP,
+        "content_security_policy_report_uri": None,
+        "content_security_policy_report_only": False,
+        "content_security_policy_nonce_in": None,
+        "referrer_policy": FSD_REFERRER_POLICY,
+        "session_cookie_secure": True,
+        "session_cookie_http_only": True,
+        "session_cookie_samesite": FSD_SESSION_COOKIE_SAMESITE,
+        "x_content_type_options": True,
+        "x_xss_protection": True,
+    }
+
+    # # Security Settings (for Talisman Config)
+    # FORCE_HTTPS = True
+    #
+    # # Content Security Policy (for Talisman Config)
+    # SECURE_CSP = {
+    #     "default-src": "'self'",
+    #     "script-src": [
+    #         "'self'",
+    #         "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='",
+    #         "'sha256-l1eTVSK8DTnK8+yloud7wZUqFrI0atVo6VlC6PJvYaQ='",
+    #     ],
+    #     "img-src": ["data:", "'self'"],
+    # }
+    #
+    # # Allow inline scripts for swagger docs (for Talisman Config)
+    # SWAGGER_CSP = {
+    #     "script-src": ["'self'", "'unsafe-inline'"],
+    #     "style-src": ["'self'", "'unsafe-inline'"],
+    # }
+    #
+    # # HTTP Strict-Transport-Security (for Talisman Config)
+    # HSTS_HEADERS = {
+    #     "strict-transport-security": (
+    #         "max-age=31536000; includeSubDomains; preload"
+    #     ),
+    #     "X-Content-Type-Options": "nosniff",
+    #     "X-Frame-Options": "SAMEORIGIN",
+    #     "X-XSS-Protection": "1; mode=block",
+    #     "Feature_Policy": (
+    #         "microphone 'none'; camera 'none'; geolocation 'none'"
+    #     ),
+    # }


### PR DESCRIPTION
Swagger did not have correct talisman config loading meaning that inline javascripts were blocked on the docs page (making swagger inaccessible).
create_app and configs updated to fix