### PR TITLE
nonce none on swagger path

### DIFF
--- a/app.py
+++ b/app.py
@@ -98,6 +98,7 @@ def create_app() -> Flask:
     def before_request_modifier():
         if request.path.startswith("/docs"):
             talisman.content_security_policy = Config.SWAGGER_CSP
+            talisman.content_security_policy_nonce_in = ["None"]
         else:
             talisman.content_security_policy = Config.SECURE_CSP
 


### PR DESCRIPTION
Swagger did not have correct talisman config loading meaning that inline javascripts were blocked on the docs page (making swagger inaccessible).