### PR TITLE
FS-987: use base64 encoded key on prod environment

### DIFF
--- a/config/envs/production.py
+++ b/config/envs/production.py
@@ -1,4 +1,5 @@
 """Flask Production Environment Configuration."""
+import base64
 from os import environ
 
 import redis
@@ -21,3 +22,9 @@ class ProductionConfig(Config):
     REDIS_MLINKS_URL = REDIS_INSTANCE_URI + "/0"
     REDIS_SESSIONS_URL = REDIS_INSTANCE_URI + "/1"
     SESSION_REDIS = redis.from_url(REDIS_SESSIONS_URL)
+    RSA256_PRIVATE_KEY = base64.b64decode(
+        environ.get("RSA256_PRIVATE_KEY_BASE64")
+    ).decode()
+    RSA256_PUBLIC_KEY = base64.b64decode(
+        environ.get("RSA256_PUBLIC_KEY_BASE64")
+    ).decode()


### PR DESCRIPTION
We want to use this as it's easier to use on PaaS.