### PR TITLE
FS-1480 restore invalid link page

### DIFF
--- a/api/magic_links/routes.py
+++ b/api/magic_links/routes.py
@@ -6,6 +6,7 @@ from api.responses import magic_link_201_response
 from api.session.auth_session import AuthSessionView
 from config import Config
 from flask import current_app
+from flask import g
 from flask import redirect
 from flask import request
 from flask import url_for
@@ -91,7 +92,8 @@ class MagicLinksView(MagicLinkMethods, MethodView):
 
     @staticmethod
     @login_required
-    def check_user_is_logged_in(account_id):
+    def check_user_is_logged_in():
+        account_id = g.account_id
         current_app.logger.info(
             f"User (account_id: {account_id}) is logged in."
         )

--- a/api/magic_links/routes.py
+++ b/api/magic_links/routes.py
@@ -62,9 +62,10 @@ class MagicLinksView(MagicLinkMethods, MethodView):
             # but the user is already logged in
             # then redirect them to the global redirect url
             current_app.logger.warn(
-                f"The magic link with hash: '{link_hash}' has already beenused"
-                f" but the user with account_id: '{g.account_id}' is logged"
-                f" in, redirecting to '{Config.MAGIC_LINK_REDIRECT_URL}'."
+                f"The magic link with hash: '{link_hash}' has already been"
+                f" used but the user with account_id: '{g.account_id}' is"
+                " logged in, redirecting to"
+                f" '{Config.MAGIC_LINK_REDIRECT_URL}'."
             )
             return redirect(Config.MAGIC_LINK_REDIRECT_URL)
         return redirect(

--- a/frontend/magic_links/routes.py
+++ b/frontend/magic_links/routes.py
@@ -8,6 +8,7 @@ from frontend.magic_links.forms import EmailForm
 from models.account import AccountError
 from models.account import AccountMethods
 from models.magic_link import MagicLinkError
+from models.magic_link import MagicLinkMethods
 from models.notification import NotificationError
 
 magic_links_bp = Blueprint(
@@ -43,8 +44,19 @@ def signed_out(status):
 
 @magic_links_bp.route("/landing/<link_id>", methods=["GET"])
 def landing(link_id):
+    """
+    Returns a magic link landing page if the link_id is found
+    or if it has been used or the link_id does not exist
+    then redirects to the invalid link route
+    :param link_id: (str) a unique single use magic link id
+    :return: 200 landing page or 302 redirect
+    """
 
-    return render_template("landing.html", link_id=link_id)
+    link_key = ":".join([Config.MAGIC_LINK_RECORD_PREFIX, link_id])
+    link_hash = MagicLinkMethods().redis_mlinks.get(link_key)
+    if link_hash:
+        return render_template("landing.html", link_id=link_id)
+    return redirect(url_for("magic_links_bp.invalid", error="Link expired"))
 
 
 @magic_links_bp.route("/new", methods=["GET", "POST"])

--- a/frontend/magic_links/routes.py
+++ b/frontend/magic_links/routes.py
@@ -58,18 +58,8 @@ def landing(link_id):
 
     link_key = ":".join([Config.MAGIC_LINK_RECORD_PREFIX, link_id])
     link_hash = MagicLinkMethods().redis_mlinks.get(link_key)
-    if link_hash:
+    if link_hash or g.is_authenticated:
         return render_template("landing.html", link_id=link_id)
-    elif g.is_authenticated:
-        # else if no link exists (or it has been used)
-        # but the user is already logged in
-        # then redirect them to the global redirect url
-        current_app.logger.warn(
-            f"The magic link with hash: '{link_hash}' has already beenused but"
-            f" the user with account_id: '{g.account_id}' is logged in,"
-            f" redirecting to '{Config.MAGIC_LINK_REDIRECT_URL}'."
-        )
-        return redirect(Config.MAGIC_LINK_REDIRECT_URL)
     return redirect(url_for("magic_links_bp.invalid", error="Link expired"))
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -103,7 +103,6 @@ dparse==0.5.2
     # via
     #   -r requirements-dev.in
     #   safety
-
 email-validator==1.2.1
     # via -r requirements.txt
 filelock==3.7.1
@@ -144,7 +143,7 @@ flask-talisman==0.8.1
     # via -r requirements.txt
 flask-wtf==1.0.0
     # via -r requirements.txt
-funding-service-design-utils @ https://github.com/communitiesuk/funding-service-design-utils/archive/refs/tags/0.0.20.tar.gz
+funding-service-design-utils @ git+https://github.com/communitiesuk/funding-service-design-utils.git@fs-1450-is-authenticated-flag
     # via -r requirements.txt
 gitdb==4.0.9
     # via gitpython

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -143,7 +143,7 @@ flask-talisman==0.8.1
     # via -r requirements.txt
 flask-wtf==1.0.0
     # via -r requirements.txt
-funding-service-design-utils @ git+https://github.com/communitiesuk/funding-service-design-utils.git@fs-1450-is-authenticated-flag
+funding-service-design-utils @ https://github.com/communitiesuk/funding-service-design-utils/archive/refs/tags/0.0.21.tar.gz
     # via -r requirements.txt
 gitdb==4.0.9
     # via gitpython

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@
 #   FSD Utils
 #-----------------------------------
 
-https://github.com/communitiesuk/funding-service-design-utils/archive/refs/tags/0.0.20.tar.gz
+git+https://github.com/communitiesuk/funding-service-design-utils.git@fs-1450-is-authenticated-flag
 
 requests
 

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@
 #   FSD Utils
 #-----------------------------------
 
-git+https://github.com/communitiesuk/funding-service-design-utils.git@fs-1450-is-authenticated-flag
+https://github.com/communitiesuk/funding-service-design-utils/archive/refs/tags/0.0.21.tar.gz
 
 requests
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ flask-talisman==0.8.1
     # via -r requirements.in
 flask-wtf==1.0.0
     # via -r requirements.in
-funding-service-design-utils @ git+https://github.com/communitiesuk/funding-service-design-utils.git@fs-1450-is-authenticated-flag
+funding-service-design-utils @ https://github.com/communitiesuk/funding-service-design-utils/archive/refs/tags/0.0.21.tar.gz
     # via -r requirements.in
 govuk-frontend-jinja==2.0.0
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ flask-talisman==0.8.1
     # via -r requirements.in
 flask-wtf==1.0.0
     # via -r requirements.in
-funding-service-design-utils @ https://github.com/communitiesuk/funding-service-design-utils/archive/refs/tags/0.0.20.tar.gz
+funding-service-design-utils @ git+https://github.com/communitiesuk/funding-service-design-utils.git@fs-1450-is-authenticated-flag
     # via -r requirements.in
 govuk-frontend-jinja==2.0.0
     # via -r requirements.in


### PR DESCRIPTION
### Restore the Invalid Link page

I have set it so that the landing page (with continue button) shows,
a/ if the link hasn’t been used, or 
b/ if you’re already logged in.
This means if you click a valid link, go to your dashboard and then click back you can still see the continue button and go forward again.
If you're not logged in and you try to re-use a magic link that you (or someone else) has already used, then you will see the invalid link page