### PR TITLE
FS-1501 Increase cookie security

### DIFF
--- a/api/session/auth_session.py
+++ b/api/session/auth_session.py
@@ -84,6 +84,9 @@ class AuthSessionView(MethodView):
             "",
             domain=Config.COOKIE_DOMAIN,
             expires=0,
+            secure=Config.SESSION_COOKIE_SECURE,
+            samesite=Config.SESSION_COOKIE_SAMESITE,
+            httponly=Config.SESSION_COOKIE_HTTPONLY,
         )
         return response
 

--- a/api/session/auth_session.py
+++ b/api/session/auth_session.py
@@ -84,9 +84,6 @@ class AuthSessionView(MethodView):
             "",
             domain=Config.COOKIE_DOMAIN,
             expires=0,
-            secure=Config.SESSION_COOKIE_SECURE,
-            samesite=Config.SESSION_COOKIE_SAMESITE,
-            httponly=Config.SESSION_COOKIE_HTTPONLY,
         )
         return response
 

--- a/app.py
+++ b/app.py
@@ -80,13 +80,8 @@ def create_app() -> Flask:
     # Initialise Redis Magic Links Store
     redis_mlinks.init_app(flask_app)
 
-    # Configure Talisman Security Settings
-    talisman = Talisman(
-        flask_app,
-        strict_transport_security=Config.HSTS_HEADERS,
-        force_https=Config.FORCE_HTTPS,
-        content_security_policy_nonce_in=["script-src"],
-    )
+    # Configure application security with Talisman
+    talisman = Talisman(flask_app, **Config.TALISMAN_SETTINGS)
 
     # This section is needed for url_for("foo", _external=True) to
     # automatically generate http scheme when this sample is

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -148,10 +148,9 @@ class DefaultConfig(object):
     if RSA256_PUBLIC_KEY_BASE64:
         RSA256_PUBLIC_KEY = base64.b64decode(RSA256_PUBLIC_KEY_BASE64).decode()
 
-    # Security Settings (for Talisman Config)
-    FORCE_HTTPS = True
+    USE_LOCAL_DATA = strtobool(getenv("USE_LOCAL_DATA", "False"))
 
-    # Content Security Policy (for Talisman Config)
+    # Secure (Default) Content Security Policy (for Talisman Config)
     SECURE_CSP = {
         "default-src": "'self'",
         "script-src": [
@@ -159,29 +158,59 @@ class DefaultConfig(object):
             "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='",
             "'sha256-l1eTVSK8DTnK8+yloud7wZUqFrI0atVo6VlC6PJvYaQ='",
         ],
+        "connect-src": "",  # APPLICATION_STORE_API_HOST_PUBLIC,
         "img-src": ["data:", "'self'"],
     }
 
-    # Allow inline scripts for swagger docs (for Talisman Config)
+    # Swagger Content Security Policy (less secure)
+    # - Allow inline scripts for swagger docs (for Talisman Config)
     SWAGGER_CSP = {
         "script-src": ["'self'", "'unsafe-inline'"],
         "style-src": ["'self'", "'unsafe-inline'"],
     }
 
-    # HTTP Strict-Transport-Security (for Talisman Config)
-    HSTS_HEADERS = {
-        "strict-transport-security": (
-            "max-age=31536000; includeSubDomains; preload"
-        ),
-        "X-Content-Type-Options": "nosniff",
-        "X-Frame-Options": "SAMEORIGIN",
-        "X-XSS-Protection": "1; mode=block",
-        "Feature_Policy": (
-            "microphone 'none'; camera 'none'; geolocation 'none'"
-        ),
+    # Talisman Config
+    FSD_REFERRER_POLICY = "strict-origin-when-cross-origin"
+    FSD_SESSION_COOKIE_SAMESITE = "Strict"
+    FSD_PERMISSIONS_POLICY = {"interest-cohort": "()"}
+    FSD_DOCUMENT_POLICY = {}
+    FSD_FEATURE_POLICY = {
+        "microphone": "'none'",
+        "camera": "'none'",
+        "geolocation": "'none'",
     }
 
-    USE_LOCAL_DATA = strtobool(getenv("USE_LOCAL_DATA", "False"))
+    DENY = "DENY"
+    SAMEORIGIN = "SAMEORIGIN"
+    ALLOW_FROM = "ALLOW-FROM"
+    ONE_YEAR_IN_SECS = 31556926
+
+    FORCE_HTTPS = True
+
+    TALISMAN_SETTINGS = {
+        "feature_policy": FSD_FEATURE_POLICY,
+        "permissions_policy": FSD_PERMISSIONS_POLICY,
+        "document_policy": FSD_DOCUMENT_POLICY,
+        "force_https": FORCE_HTTPS,
+        "force_https_permanent": False,
+        "force_file_save": False,
+        "frame_options": "SAMEORIGIN",
+        "frame_options_allow_from": None,
+        "strict_transport_security": True,
+        "strict_transport_security_preload": True,
+        "strict_transport_security_max_age": ONE_YEAR_IN_SECS,
+        "strict_transport_security_include_subdomains": True,
+        "content_security_policy": SECURE_CSP,
+        "content_security_policy_report_uri": None,
+        "content_security_policy_report_only": False,
+        "content_security_policy_nonce_in": None,
+        "referrer_policy": FSD_REFERRER_POLICY,
+        "session_cookie_secure": True,
+        "session_cookie_http_only": True,
+        "session_cookie_samesite": FSD_SESSION_COOKIE_SAMESITE,
+        "x_content_type_options": True,
+        "x_xss_protection": True,
+    }
 
     COF_FUND_ID = "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4"
     COF_ROUND2_ID = "c603d114-5364-4474-a0c4-c41cbf4d3bbd"

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -36,6 +36,7 @@ class DevelopmentConfig(Config):
     # in the app's registration in the Azure portal.
     AZURE_AD_REDIRECT_URI = AUTHENTICATOR_HOST + AZURE_AD_REDIRECT_PATH
 
+    # Session Settings
     SESSION_TYPE = (
         # Specifies how the token cache should be stored
         # in server-side session

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -14,7 +14,6 @@ class DevelopmentConfig(Config):
     SESSION_COOKIE_NAME = "session_cookie"
     FLASK_ENV = "development"
     COOKIE_DOMAIN = None
-    SESSION_COOKIE_SECURE = False
 
     # Logging
     FSD_LOG_LEVEL = logging.DEBUG
@@ -45,6 +44,7 @@ class DevelopmentConfig(Config):
     )
     SESSION_PERMANENT = False
     SESSION_USE_SIGNER = True
+    SESSION_COOKIE_SECURE = False
 
     # RSA 256 KEYS
     if not hasattr(Config, "RSA256_PRIVATE_KEY"):

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -78,4 +78,4 @@ class DevelopmentConfig(Config):
     )
 
     # Security
-    FORCE_HTTPS = False
+    Config.TALISMAN_SETTINGS["force_https"] = False

--- a/config/envs/unit_test.py
+++ b/config/envs/unit_test.py
@@ -10,9 +10,7 @@ from fsd_utils import configclass
 class UnitTestConfig(Config):
     #  Application Config
     SECRET_KEY = "dev"
-    SESSION_COOKIE_NAME = "session_cookie"
     COOKIE_DOMAIN = None
-    SESSION_COOKIE_SECURE = False
 
     # Logging
     FSD_LOG_LEVEL = logging.DEBUG
@@ -43,6 +41,7 @@ class UnitTestConfig(Config):
     )
     SESSION_PERMANENT = False
     SESSION_USE_SIGNER = True
+    SESSION_COOKIE_SECURE = False
 
     # RSA 256 KEYS
     _test_private_key_path = (

--- a/config/envs/unit_test.py
+++ b/config/envs/unit_test.py
@@ -64,8 +64,7 @@ class UnitTestConfig(Config):
     NOTIFICATION_SERVICE_HOST = "notification_service"
 
     # Security
-    FORCE_HTTPS = False
-    STRICT_CSP = False
+    Config.TALISMAN_SETTINGS["force_https"] = False
 
     APPLICANT_FRONTEND_HOST = "frontend"
     APPLICANT_FRONTEND_ACCESSIBILITY_STATEMENT_URL = "/accessibility_statement"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -133,7 +133,7 @@ flask-migrate==3.1.0
     # via -r requirements.txt
 flask-redis==0.4.0
     # via -r requirements.txt
-flask-session==0.3.2
+flask-session==0.4.0
     # via -r requirements.txt
 flask-sqlalchemy==2.5.1
     # via
@@ -151,6 +151,10 @@ gitpython==3.1.27
     # via bandit
 govuk-frontend-jinja==2.0.0
     # via -r requirements.txt
+greenlet==1.1.3
+    # via
+    #   -r requirements.txt
+    #   sqlalchemy
 gunicorn==20.1.0
     # via
     #   -r requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -31,7 +31,7 @@ email-validator==1.2.1
 #   Redis / Session Management
 #-----------------------------------
 flask-redis==0.4.0
-Flask-Session==0.3.2
+Flask-Session==0.4.0
 flask-talisman==0.8.1
 PyJWT==2.4.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,7 +69,7 @@ flask-migrate==3.1.0
     # via -r requirements.in
 flask-redis==0.4.0
     # via -r requirements.in
-flask-session==0.3.2
+flask-session==0.4.0
     # via -r requirements.in
 flask-sqlalchemy==2.5.1
     # via
@@ -83,6 +83,8 @@ funding-service-design-utils==1.0.0
     # via -r requirements.in
 govuk-frontend-jinja==2.0.0
     # via -r requirements.in
+greenlet==1.1.3
+    # via sqlalchemy
 gunicorn==20.1.0
     # via funding-service-design-utils
 idna==3.3


### PR DESCRIPTION
### Add HttpOnly, SameSite and Secure cookie settings to session_cookie and fsd_auth_token cookie settings

- Enable SameSite session cookie setting by upgrading flask-session to version 0.4.0
- Update talisman initialisation method to use default config dictionary setting approach
- Clearer grouping of config session settings