### PR TITLE
prevent dependabot deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,7 @@ jobs:
 #          path: /home/runner/work/funding-service-design-authenticator/funding-service-design-authenticator/axe_reports/*.html
 #          retention-days: 5
   deploy_dev:
+    if: github.actor != 'dependabot[bot]'
     needs: testing
     runs-on: ubuntu-latest
     environment: Dev

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
 #          path: /home/runner/work/funding-service-design-authenticator/funding-service-design-authenticator/axe_reports/*.html
 #          retention-days: 5
   deploy_dev:
-    if: github.actor != 'dependabot[bot]'
+    if: ${{ github.actor != 'dependabot[bot]' }}
     needs: testing
     runs-on: ubuntu-latest
     environment: Dev


### PR DESCRIPTION
dependabot cannot share action secrets, the action secrets are required for deploying to environments (dev and test). If dependabot opens a PR then this fix will now prevent deployments to dev. This approach relies on testing to catch any problems with a package bump - when merged the journey will be tested in our test environment before released to higher environments. 
*An alternative to this is to set the deployment secrets as dependabot secrets.