### PR TITLE
FS-1133: restore magic link search endpoint on non-prod environments

### DIFF
--- a/models/magic_link.py
+++ b/models/magic_link.py
@@ -10,7 +10,9 @@ from typing import List
 from typing import TYPE_CHECKING
 
 from config import Config
+from flask import abort
 from flask import current_app
+from flask import Response
 from flask_redis import FlaskRedis
 from security.utils import create_token
 
@@ -42,6 +44,18 @@ class MagicLinkError(Exception):
 
 
 class MagicLinkMethods(object):
+    def search(self):
+        """
+        GET /magic-links endpoint
+        :return: Json Response
+        """
+        if not Config.FLASK_ENV == "production":
+            return Response(
+                json.dumps(self.links), mimetype="application/json"
+            )
+        else:
+            return abort(403)
+
     @property
     def redis_mlinks(self) -> FlaskRedis:
         """

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -12,6 +12,21 @@ tags:
     description: Session operations
 paths:
   /magic-links:
+    get:
+      tags:
+        - magic links
+      summary: Search magic link
+      description: List all magic links
+      operationId: api.MagicLinksView.search
+      responses:
+        200:
+          description: SUCCESS - A list of magic link keys
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
     post:
       tags:
         - magic links

--- a/tests/mocks/redis_magic_links.py
+++ b/tests/mocks/redis_magic_links.py
@@ -9,7 +9,7 @@ ml_data = {}
 class RedisMLinks(object):
     @staticmethod
     def keys(match: str = "*"):
-        return [link for link, value in ml_data.items()]
+        return [bytes(link, "utf-8") for link, value in ml_data.items()]
 
     @staticmethod
     def set(key, val):


### PR DESCRIPTION
Restores `/search` endpoint removed in #35 but restricts it to non-production environments (for use by End-to-end tests)