### PR TITLE
BAU: fix redis service name

### DIFF
--- a/config/envs/production.py
+++ b/config/envs/production.py
@@ -8,7 +8,7 @@ from fsd_utils import configclass
 class ProductionConfig(Config):
 
     # Redis
-    REDIS_INSTANCE_NAME = "funding-service-magic-links-production"
+    REDIS_INSTANCE_NAME = "funding-service-magic-links"
     REDIS_INSTANCE_URI = Config.VCAP_SERVICES.get_service_credentials_value(
         "redis", REDIS_INSTANCE_NAME, "uri"
     )


### PR DESCRIPTION
We are no longer namespacing this with the environment