### PR TITLE
FS-2046: Pull cookie domain from env var

### DIFF
--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -17,7 +17,7 @@ class DefaultConfig(object):
     SECRET_KEY = environ.get("SECRET_KEY")
     SESSION_COOKIE_NAME = environ.get("SESSION_COOKIE_NAME", "session_cookie")
 
-    COOKIE_DOMAIN = None
+    COOKIE_DOMAIN = environ.get("COOKIE_DOMAIN", None)
 
     FLASK_ROOT = str(Path(__file__).parent.parent.parent)
     FLASK_ENV = environ.get("FLASK_ENV")
@@ -50,7 +50,7 @@ class DefaultConfig(object):
     AZURE_AD_CLIENT_SECRET = environ.get("AZURE_AD_CLIENT_SECRET")
     AZURE_AD_TENANT_ID = environ.get("AZURE_AD_TENANT_ID", "")
     AZURE_AD_AUTHORITY = (
-        # consumers|organizations|<tenant_id> - signifies the Azure AD tenant endpoint
+        # consumers|organizations|<tenant_id> - signifies the Azure AD tenant endpoint # noqa
         "https://login.microsoftonline.com/"
         + AZURE_AD_TENANT_ID
     )

--- a/config/envs/dev.py
+++ b/config/envs/dev.py
@@ -1,6 +1,5 @@
 """Flask Dev Pipeline Environment Configuration."""
 import logging
-from os import environ
 
 import redis
 from config.envs.default import DefaultConfig as Config
@@ -11,8 +10,6 @@ from fsd_utils import configclass
 class DevConfig(Config):
     #  Application Config
     SECRET_KEY = "dev"
-
-    COOKIE_DOMAIN = environ.get("COOKIE_DOMAIN", ".dev.fundingservice.co.uk")
 
     # Logging
     FSD_LOG_LEVEL = logging.INFO


### PR DESCRIPTION
- Change default config, pull cookie domain from COOKIE_DOMAIN env var
- If COOKIE_DOMAIN env var is not set, it will default to None


This is needed to persist the `language` cookie when going from frontend -> authenticator.