### PR TITLE
FIX: Enable update on first time SSO login on existing account

### DIFF
--- a/api/sso/routes.py
+++ b/api/sso/routes.py
@@ -4,6 +4,7 @@ import json
 import msal
 import requests
 from config import Config
+from flask import abort
 from flask import redirect
 from flask import request
 from flask import session
@@ -11,6 +12,7 @@ from flask import current_app
 from flask import make_response
 from flask.views import MethodView
 from models.account import AccountMethods
+from models.account import AccountError
 from api.session.auth_session import AuthSessionView
 
 

--- a/tests/api_data/post_endpoint_data.json
+++ b/tests/api_data/post_endpoint_data.json
@@ -15,10 +15,10 @@
       "email_address": "new_user@example.com",
       "roles": []
     },
-    "email_address=sso%40example.com&azure_ad_subject_id=abc": {
+    "email_address=sso%40example.com": {
       "account_id": "usersso",
       "azure_ad_subject_id": "abc",
-      "full_name": "Test User",
+      "full_name": null,
       "email_address": "sso@example.com",
       "roles": []
     }

--- a/tests/mocks/msal.py
+++ b/tests/mocks/msal.py
@@ -30,6 +30,20 @@ expected_fsd_user_token_claims = {
     }
 
 
+# Hijacked id_token_claims object received from Azure AD
+# with bad "sub" (Azure AD subject ID)
+bad_id_token_claims = {
+    "name": "Test User SSO",
+    "id": 123,
+    "sub": "xyx",
+    "preferred_username": "sso@example.com",
+    "roles": [
+        "LeadAssessor",
+        "Assessor",
+        "Commenter"
+    ]
+}
+
 class Account(dict):
     pass
 
@@ -57,6 +71,17 @@ class ConfidentialClientApplication(object):
         **kwargs,
     ):
         return accounts
+
+
+class HijackedConfidentialClientApplication(ConfidentialClientApplication):
+    def acquire_token_by_auth_code_flow(
+        self, auth_code_flow, auth_response, scopes=None, **kwargs
+    ):
+        return {
+            "id_token": 1,
+            "access_token": 2,
+            "id_token_claims": bad_id_token_claims,
+        }
 
 
 @pytest.fixture()

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -2,6 +2,10 @@ from flask import session
 from tests.mocks.msal import id_token_claims
 from tests.mocks.msal import expected_fsd_user_token_claims
 from fsd_utils.authentication.utils import validate_token_rs256
+from tests.mocks.msal import ConfidentialClientApplication
+from tests.mocks.msal import HijackedConfidentialClientApplication
+from models.account import AccountError
+import pytest
 
 
 def test_sso_login_redirects_to_ms(flask_test_client):
@@ -62,6 +66,41 @@ def test_sso_get_token_sets_session_and_redirects(
 
     assert response.status_code == 302
     assert session.get("user") == id_token_claims
+
+
+def test_sso_get_token_prevents_overwrite_of_existing_azure_subject_id(
+    flask_test_client, mocker, caplog
+):
+    """
+    GIVEN We have a functioning Authenticator API
+    WHEN a GET request for /sso/get-token with a valid
+        response from azure_ad via the mock_msal_client_application
+    THEN we should receive a 302 redirect response with
+        the correct claims in the session
+    """
+    mocker.patch(
+        "msal.ConfidentialClientApplication.acquire_token_by_auth_code_flow",
+        ConfidentialClientApplication.acquire_token_by_auth_code_flow,
+    )
+    endpoint = "/sso/get-token"
+    response = flask_test_client.get(endpoint)
+
+    assert response.status_code == 302
+    assert session.get("user") == id_token_claims
+
+    mocker.patch(
+        "msal.ConfidentialClientApplication.acquire_token_by_auth_code_flow",
+        HijackedConfidentialClientApplication.acquire_token_by_auth_code_flow,
+    )
+
+    endpoint = "/sso/get-token"
+    error_response = flask_test_client.get(endpoint)
+
+    assert error_response.status_code == 500
+    assert "Cannot update account id: usersso - " \
+           "attempting to update existing azure_ad_subject_id " \
+           "from abc to xyx which is not allowed." in caplog.text
+
 
 
 def test_sso_get_token_sets_expected_fsd_user_token_cookie_claims(


### PR DESCRIPTION
### Enable update on first time SSO login on existing account

- Update create_or_update_account() upsert behaviour to allow users with existing account to have their azure_ad_subject_id updated on first SSO login, while still preventing azure_ad_subject_id from being modified once associated
- Update tests to check correct exception raised