### PR TITLE
BAU: Modify update_account method to log an error if a user with no roles signs in.

### DIFF
--- a/frontend/user/routes.py
+++ b/frontend/user/routes.py
@@ -24,6 +24,7 @@ def user():
        - roles_required: List[str] is set by checking if
          logged_in_user
     """
+    status_code = 200
     roles_required = request.args.get("roles_required")
     logged_in_user = g.user if g.is_authenticated else None
     if logged_in_user:
@@ -33,6 +34,8 @@ def user():
                 for role_required in roles_required.upper().split("|")
             ):
                 roles_required = None
+            else:
+                status_code = 403
     return render_template(
         "user.html",
         roles_required=roles_required,
@@ -40,4 +43,4 @@ def user():
         login_url=Config.SSO_LOGIN_ENDPOINT,
         logout_url=Config.SSO_LOGOUT_ENDPOINT,
         support_mailbox=Config.SUPPORT_MAILBOX_EMAIL,
-    )
+    ), status_code

--- a/models/account.py
+++ b/models/account.py
@@ -103,7 +103,15 @@ class AccountMethods(Account):
             Account object or None
         """
         url = Config.ACCOUNT_STORE_API_HOST + Config.ACCOUNT_ENDPOINT.format(account_id=id)
-        cleaned_roles = [azure_ad_role_map[role] for role in roles]
+        cleaned_roles = []
+        if isinstance(roles, List):
+            cleaned_roles = [azure_ad_role_map[role] for role in roles]
+        if len(cleaned_roles) == 0:
+            current_app.logger.error(
+                f"When attempting to update account id: {id} "
+                f"with email: {email} - no roles were found"
+            )
+
         params = {
             "email_address": email,
             "azure_ad_subject_id": azure_ad_subject_id,

--- a/models/account.py
+++ b/models/account.py
@@ -108,8 +108,7 @@ class AccountMethods(Account):
             cleaned_roles = [azure_ad_role_map[role] for role in roles]
         if len(cleaned_roles) == 0:
             current_app.logger.error(
-                f"When attempting to update account id: {id} "
-                f"with email: {email} - no roles were found"
+                f"account id: {id} has not been assigned any roles"
             )
 
         params = {

--- a/tests/api_data/put_endpoint_data.json
+++ b/tests/api_data/put_endpoint_data.json
@@ -16,11 +16,7 @@
       "full_name": "Test User SSO",
       "azure_ad_subject_id": "abc",
       "email_address": "sso@example.com",
-      "roles": [
-        "LEAD_ASSESSOR",
-        "ASSESSOR",
-        "COMMENTER"
-      ]
+      "roles": []
     }
   }
 }

--- a/tests/api_data/put_endpoint_data.json
+++ b/tests/api_data/put_endpoint_data.json
@@ -10,6 +10,17 @@
         "ASSESSOR",
         "COMMENTER"
       ]
+    },
+    "email_address=sso%40example.com&azure_ad_subject_id=abc&full_name=Test+User+SSO&roles=%5B%5D": {
+      "account_id": "usersso",
+      "full_name": "Test User SSO",
+      "azure_ad_subject_id": "abc",
+      "email_address": "sso@example.com",
+      "roles": [
+        "LEAD_ASSESSOR",
+        "ASSESSOR",
+        "COMMENTER"
+      ]
     }
   }
 }

--- a/tests/mocks/msal.py
+++ b/tests/mocks/msal.py
@@ -29,6 +29,15 @@ expected_fsd_user_token_claims = {
         "roles": ["LEAD_ASSESSOR", "ASSESSOR", "COMMENTER"],
     }
 
+# Role-less fsd-user-token claims
+roleless_fsd_user_token_claims = {
+    "name": "Test User SSO",
+    "id": 123,
+    "sub": "abc",
+    "preferred_username": "sso@example.com",
+    "roles": []
+}
+
 
 # Hijacked id_token_claims object received from Azure AD
 # with bad "sub" (Azure AD subject ID)
@@ -83,6 +92,16 @@ class HijackedConfidentialClientApplication(ConfidentialClientApplication):
             "id_token_claims": bad_id_token_claims,
         }
 
+
+class RolelessConfidentialClientApplication(ConfidentialClientApplication):
+    def acquire_token_by_auth_code_flow(
+        self, auth_code_flow, auth_response, scopes=None, **kwargs
+    ):
+        return {
+            "id_token": 1,
+            "access_token": 2,
+            "id_token_claims": roleless_fsd_user_token_claims,
+        }
 
 @pytest.fixture()
 def mock_msal_client_application(mocker):

--- a/tests/test_signout.py
+++ b/tests/test_signout.py
@@ -148,7 +148,7 @@ class TestSignout:
             "/service/user?roles_required=ultimate_assessor|mega_assessor"
         )
         response = flask_test_client.get(endpoint)
-        assert response.status_code == 200
+        assert response.status_code == 403
         assert (
             """<p class="govuk-body">You do not have access as your account does not have the right permissions set up."""  # noqa
             in response.get_data(as_text=True)

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -4,6 +4,7 @@ from tests.mocks.msal import expected_fsd_user_token_claims
 from fsd_utils.authentication.utils import validate_token_rs256
 from tests.mocks.msal import ConfidentialClientApplication
 from tests.mocks.msal import HijackedConfidentialClientApplication
+from tests.mocks.msal import RolelessConfidentialClientApplication
 from models.account import AccountError
 import pytest
 
@@ -101,7 +102,28 @@ def test_sso_get_token_prevents_overwrite_of_existing_azure_subject_id(
            "attempting to update existing azure_ad_subject_id " \
            "from abc to xyx which is not allowed." in caplog.text
 
+def test_sso_get_token_logs_error_for_roleless_users(
+    flask_test_client, mocker, caplog
+):
+    """
+    GIVEN We have a functioning Authenticator API
+    WHEN a GET request for /sso/get-token with a valid
+        response from azure_ad via the mock_msal_client_application
+    THEN we should receive a 302 redirect response with
+        the correct claims in the session
+    """
+    mocker.patch(
+        "msal.ConfidentialClientApplication.acquire_token_by_auth_code_flow",
+        RolelessConfidentialClientApplication.acquire_token_by_auth_code_flow,
+    )
 
+    endpoint = "/sso/get-token"
+    error_response = flask_test_client.get(endpoint)
+
+    assert error_response.status_code == 302
+    assert "When attempting to update account id: " \
+           "usersso with email: sso@example.com " \
+           "- no roles were found" in caplog.text
 
 def test_sso_get_token_sets_expected_fsd_user_token_cookie_claims(
         flask_test_client, mock_msal_client_application

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -121,9 +121,7 @@ def test_sso_get_token_logs_error_for_roleless_users(
     error_response = flask_test_client.get(endpoint)
 
     assert error_response.status_code == 302
-    assert "When attempting to update account id: " \
-           "usersso with email: sso@example.com " \
-           "- no roles were found" in caplog.text
+    assert "account id: usersso has not been assigned any roles" in caplog.text
 
 def test_sso_get_token_sets_expected_fsd_user_token_cookie_claims(
         flask_test_client, mock_msal_client_application


### PR DESCRIPTION
### Log error if user with no roles signs in (but allow authentication)

- Modify update_account method to log an error if a user with no roles attempts to authenticate, but otherwise allow authentication and session creation to succeed
- Test added to confirm the behaviour above