### PR TITLE
FS-2190: set unique title tags

### DIFF
--- a/frontend/magic_links/templates/check_email.html
+++ b/frontend/magic_links/templates/check_email.html
@@ -3,19 +3,26 @@
 {%- from "govuk_frontend_jinja/components/panel/macro.html" import govukPanel -%}
 
 {% extends "base.html" %}
+{% set pageHeading %}
+{% if email %}
+  {% trans %}Email sent{% endtrans %}
+{% else %}
+  {% trans %}Email not sent{% endtrans %}
+{% endif %}
+{% endset %}
 
 {% block content %}
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         {% if not email %}
-            <h1 class="govuk-heading-l govuk-!-margin-top-2">{% trans %}Email not sent{% endtrans %}</h1>
+            <h1 class="govuk-heading-l govuk-!-margin-top-2">{{pageHeading}}</h1>
 
             <p class="govuk-body">{% trans %}No email has been sent.{% endtrans %}</p>
             <p class="govuk-body">{% trans %}If you need a link to access your applications you can {% endtrans %}<a href="{{url_for('magic_links_bp.new')}}" class="govuk-link govuk-link--no-visited-state">{% trans %}request a new link{% endtrans %}</a>.</p>
 
         {% else %}
-            <h1 class="govuk-heading-l govuk-!-margin-top-2">{% trans %}Email sent{% endtrans %}</h1>
+            <h1 class="govuk-heading-l govuk-!-margin-top-2">{{pageHeading}}</h1>
 
             <p class="govuk-body">{% trans %}We have sent an email to {% endtrans %}<span class="govuk-!-font-weight-bold">{{ email }}</span></p>
             <h2 class="govuk-heading-m">{% trans %}What happens next{% endtrans %}</h2>

--- a/frontend/magic_links/templates/email.html
+++ b/frontend/magic_links/templates/email.html
@@ -3,6 +3,7 @@
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 
 {% extends "base.html" %}
+{% set pageHeading %}{% trans %}Email address{% endtrans %}{% endset %}
 
 {% block content %}
     <div class="govuk-grid-row">
@@ -16,7 +17,8 @@
             <form action="" class="form" method="post">
                 <div class="govuk-form-group">
                     <h1 class="govuk-label-wrapper"><label class="govuk-label govuk-label--l" for="email">
-                        {% trans %}Email address {% endtrans %}</label>
+                        {{pageHeading}}
+                    </label>
                     </h1>
                     {{ form.hidden_tag() }}
                     {{ govukInput({

--- a/frontend/magic_links/templates/invalid.html
+++ b/frontend/magic_links/templates/invalid.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 {%- from "govuk_frontend_jinja/components/inset-text/macro.html" import govukInsetText -%}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
-
+{% set pageHeading %}{% trans %}Link expired{% endtrans %}{% endset %}
 {% block content %}
   <div>
       {# TODO: Figure out translation for Link expired #}
-      <h1 class="govuk-heading-xl">{% trans %} Link expired {% endtrans %}</h1>
+      <h1 class="govuk-heading-xl">{{pageHeading}}</h1>
   </div>
 <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" data-module="govuk-error-summary">
   <h2 class="govuk-error-summary__title" id="error-summary-title">

--- a/frontend/magic_links/templates/signed_out.html
+++ b/frontend/magic_links/templates/signed_out.html
@@ -1,15 +1,18 @@
 {% extends "base.html" %}
+{% set pageHeading %}
+{% if status == "no_token" %}
+    {% trans %}You are not logged in{% endtrans %}
+{% else %}
+    {% trans %}You have been signed out{% endtrans %}
+{% endif %}
+{% endset %}
 {%- from "govuk_frontend_jinja/components/inset-text/macro.html" import govukInsetText -%}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
 
 {% block content %}
   <div>
       <h1 class="govuk-heading-xl">
-          {% if status == "no_token" %}
-            {% trans %}You are not logged in{% endtrans %}
-          {% else %}
-            {% trans %}You have been signed out{% endtrans %}
-          {% endif %}
+        {{pageHeading}}
       </h1>
   </div>
 {% if status != "no_token" %}

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -2,7 +2,7 @@
 
 {% set assetPath = url_for('static', filename='').rstrip('/') %}
 
-{% block pageTitle %}{{ service_title }}{% endblock %}
+{% block pageTitle %}{{[pageHeading, service_title]|join(' - ') if pageHeading else service_title}}{% endblock %}
 
 {% block head %}
   {% include 'head.html' %}


### PR DESCRIPTION
Sibling PR to https://github.com/communitiesuk/funding-service-design-frontend/pull/243 

Uses same approach as https://github.com/communitiesuk/funding-service-design-frontend/pull/243 to extract the `h1` into a `pageHeading` variable and then pull that into the `title` if specified