### PR TITLE
bau-auth-service-name-fix

### DIFF
--- a/app.py
+++ b/app.py
@@ -130,10 +130,11 @@ def create_app() -> Flask:
     @flask_app.context_processor
     def inject_service_name():
         fund_title = FundMethods.get_service_name()
-        if fund_title:
-            return dict(service_title=gettext("Apply for") + " " + fund_title)
-        else:
-            return dict(service_title="Access Funding")
+        return (
+            dict(service_title=gettext("Apply for") + " " + fund_title)
+            if fund_title
+            else dict(service_title="Access Funding")
+        )
 
     with flask_app.app_context():
         from frontend.default.routes import (

--- a/app.py
+++ b/app.py
@@ -6,7 +6,6 @@ import connexion
 import prance
 from config import Config
 from connexion.resolver import MethodViewResolver
-from flask import current_app
 from flask import Flask
 from flask import request
 from flask_assets import Environment
@@ -130,12 +129,10 @@ def create_app() -> Flask:
 
     @flask_app.context_processor
     def inject_service_name():
-        try:
-            fund_title = FundMethods.get_service_name()
+        fund_title = FundMethods.get_service_name()
+        if fund_title:
             return dict(service_title=gettext("Apply for") + " " + fund_title)
-
-        except Exception as e:  # noqa
-            current_app.log_exception(e)
+        else:
             return dict(service_title="Access Funding")
 
     with flask_app.app_context():

--- a/frontend/magic_links/routes.py
+++ b/frontend/magic_links/routes.py
@@ -1,4 +1,5 @@
 from config import Config
+from flask import abort
 from flask import Blueprint
 from flask import current_app
 from flask import g
@@ -65,6 +66,11 @@ def landing(link_id):
     )
 
     fund_data = FundMethods.get_fund(fund_short_name)
+    if not fund_data:
+        current_app.logger.warn(
+            "Fund and round information missing from query string"
+        )
+        return abort(404)
     fund_name = fund_data.name
     submission_deadline = round_data.deadline
     link_key = ":".join([Config.MAGIC_LINK_RECORD_PREFIX, link_id])


### PR DESCRIPTION
Sentry has logged issues where auth crashes when fund and round ids are not passed as query parameters. This is not the intended usecase as we always expect the user to go through a flow were the fund and round details are passed from frontend to auth, however we still should make sure the app does not crash even if these are not being passed thorugh.