### PR TITLE
bau-fix-request-new-magic-link

### DIFF
--- a/frontend/magic_links/routes.py
+++ b/frontend/magic_links/routes.py
@@ -149,4 +149,6 @@ def check_email():
     return render_template(
         "check_email.html",
         email=request.args.get("email"),
+        fund=request.args.get("fund"),
+        round=request.args.get("round"),
     )

--- a/frontend/magic_links/templates/check_email.html
+++ b/frontend/magic_links/templates/check_email.html
@@ -39,7 +39,7 @@
               </summary>
               <div class="govuk-details__text">
                 <p class="govuk-body">{% trans %}The email may take a few minutes to arrive.{% endtrans %}</p>
-                <p class="govuk-body">{% trans %}Check your spam or junk folders – if it still has not arrived, you can {% endtrans %}<a href="{{url_for('magic_links_bp.new')}}" class="govuk-link govuk-link--no-visited-state">{% trans %}request a new link{% endtrans %}</a>.</p>
+                <p class="govuk-body">{% trans %}Check your spam or junk folders – if it still has not arrived, you can {% endtrans %}<a href="{{url_for('magic_links_bp.new', fund=fund, round=round)}}" class="govuk-link govuk-link--no-visited-state">{% trans %}request a new link{% endtrans %}</a>.</p>
               </div>
             </details>
 


### PR DESCRIPTION
request new magic link link redirects to the new() route without setting the appropriate fund and round query params, this PR adds the fix for this.