### PR TITLE
fs-2676-update-requesting-new-link

### DIFF
--- a/api/magic_links/routes.py
+++ b/api/magic_links/routes.py
@@ -34,8 +34,8 @@ class MagicLinksView(MagicLinkMethods, MethodView):
         :return: 302 Redirect / 404 Error
         """
 
-        fund = request.args.get("fund")
-        round = request.args.get("round")
+        fund_short_name = request.args.get("fund")
+        round_short_name = request.args.get("round")
 
         link_key = ":".join([Config.MAGIC_LINK_RECORD_PREFIX, link_id])
         link_hash = self.redis_mlinks.get(link_key)
@@ -60,7 +60,11 @@ class MagicLinksView(MagicLinkMethods, MethodView):
                     f"non-existent account_id {link.get('accountId')}"
                 )
                 redirect(
-                    url_for("magic_links_bp.invalid", fund=fund, round=round)
+                    url_for(
+                        "magic_links_bp.invalid",
+                        fund=fund_short_name,
+                        round=round_short_name,
+                    )
                 )
 
             # Check link is not expired
@@ -69,13 +73,15 @@ class MagicLinksView(MagicLinkMethods, MethodView):
                     account=account,
                     is_via_magic_link=True,
                     redirect_url=link.get("redirectUrl"),
+                    fund=fund_short_name,
+                    round=round_short_name,
                 )
             return redirect(
                 url_for(
                     "magic_links_bp.invalid",
                     error="Link expired",
-                    fund=fund,
-                    round=round,
+                    fund=fund_short_name,
+                    round=round_short_name,
                 )
             )
 
@@ -94,8 +100,8 @@ class MagicLinksView(MagicLinkMethods, MethodView):
             url_for(
                 "magic_links_bp.invalid",
                 error="Link expired",
-                fund=fund,
-                round=round,
+                fund=fund_short_name,
+                round=round_short_name,
             )
         )
 

--- a/api/session/auth_session.py
+++ b/api/session/auth_session.py
@@ -55,8 +55,8 @@ class AuthSessionView(MethodView):
 
         Returns: 302 redirect to signed-out page
         """
-        fund = None
-        round = None
+        fund_short_name = None
+        round_short_name = None
         existing_auth_token = request.cookies.get(
             Config.FSD_USER_TOKEN_COOKIE_NAME
         )
@@ -76,8 +76,8 @@ class AuthSessionView(MethodView):
                 status = "invalid_token"
 
             # Create query params for signout url if valid token
-            fund = valid_token.get("fund")
-            round = valid_token.get("round")
+            fund_short_name = valid_token.get("fund")
+            round_short_name = valid_token.get("round")
 
             # If validly issued token, clear the redis store
             # of the account and link record
@@ -94,8 +94,8 @@ class AuthSessionView(MethodView):
         signed_out_url = url_for(
             "magic_links_bp.signed_out",
             status=status,
-            fund=fund,
-            round=round,
+            fund=fund_short_name,
+            round=round_short_name,
         )
         response = make_response(redirect(signed_out_url), 302)
         response.set_cookie(

--- a/api/session/auth_session.py
+++ b/api/session/auth_session.py
@@ -156,9 +156,9 @@ class AuthSessionView(MethodView):
         cls,
         account: "Account",
         is_via_magic_link: bool,
+        fund: str,
+        round: str,
         timeout_seconds: int = Config.FSD_SESSION_TIMEOUT_SECONDS,
-        fund: str = None,
-        round: str = round,
     ):
         """
         Creates a signed expiring session token for the given account

--- a/api/session/auth_session.py
+++ b/api/session/auth_session.py
@@ -55,6 +55,8 @@ class AuthSessionView(MethodView):
 
         Returns: 302 redirect to signed-out page
         """
+        fund = None
+        round = None
         existing_auth_token = request.cookies.get(
             Config.FSD_USER_TOKEN_COOKIE_NAME
         )
@@ -73,6 +75,10 @@ class AuthSessionView(MethodView):
             except jwt.PyJWTError:
                 status = "invalid_token"
 
+            # Create query params for signout url if valid token
+            fund = valid_token.get("fund")
+            round = valid_token.get("round")
+
             # If validly issued token, clear the redis store
             # of the account and link record
             if valid_token and isinstance(valid_token, dict):
@@ -88,8 +94,8 @@ class AuthSessionView(MethodView):
         signed_out_url = url_for(
             "magic_links_bp.signed_out",
             status=status,
-            fund=request.args.get("fund"),
-            round=request.args.get("round"),
+            fund=fund,
+            round=round,
         )
         response = make_response(redirect(signed_out_url), 302)
         response.set_cookie(
@@ -107,6 +113,8 @@ class AuthSessionView(MethodView):
         redirect_url: str,
         is_via_magic_link: bool,
         timeout_seconds: int = Config.FSD_SESSION_TIMEOUT_SECONDS,
+        fund: str = None,
+        round: str = None,
     ):
         """
         Sets a user session token in the client for a given account_id
@@ -119,7 +127,11 @@ class AuthSessionView(MethodView):
         """
         try:
             session_details = cls.create_session_details_with_token(
-                account, is_via_magic_link, timeout_seconds=timeout_seconds
+                account,
+                is_via_magic_link,
+                timeout_seconds=timeout_seconds,
+                fund=fund,
+                round=round,
             )
             response = make_response(redirect(redirect_url), 302)
             expiry = datetime.now() + timedelta(seconds=timeout_seconds)
@@ -145,6 +157,8 @@ class AuthSessionView(MethodView):
         account: "Account",
         is_via_magic_link: bool,
         timeout_seconds: int = Config.FSD_SESSION_TIMEOUT_SECONDS,
+        fund: str = None,
+        round: str = round,
     ):
         """
         Creates a signed expiring session token for the given account
@@ -163,6 +177,8 @@ class AuthSessionView(MethodView):
             else account.roles,
             "iat": int(datetime.now().timestamp()),
             "exp": int(datetime.now().timestamp() + timeout_seconds),
+            "fund": fund,
+            "round": round,
         }
 
         session_details.update({"token": create_token(session_details)})

--- a/frontend/magic_links/routes.py
+++ b/frontend/magic_links/routes.py
@@ -75,6 +75,8 @@ def landing(link_id):
         )
         return abort(404)
 
+    fund_short_name = fund_data.short_name
+    round_short_name = round_data.short_name
     fund_name = fund_data.name
     submission_deadline = round_data.deadline
     link_key = ":".join([Config.MAGIC_LINK_RECORD_PREFIX, link_id])
@@ -87,9 +89,11 @@ def landing(link_id):
             submission_deadline=submission_deadline,
             fund_name=fund_name,
             round_title=round_data.title,
+            fund_short_name=fund_short_name,
+            round_short_name=round_short_name,
             all_questions_url=Config.APPLICATION_ALL_QUESTIONS_URL.format(
-                fund_short_name=fund_data.short_name,
-                round_short_name=round_data.short_name,
+                fund_short_name=fund_short_name,
+                round_short_name=round_short_name,
             ),
         )
     return redirect(

--- a/frontend/magic_links/templates/landing.html
+++ b/frontend/magic_links/templates/landing.html
@@ -17,7 +17,7 @@
 
     {{ govukButton({
       "text": gettext("Continue"),
-      "href": url_for('api_MagicLinksView_use', link_id=link_id),
+      "href": url_for('api_MagicLinksView_use', link_id=link_id, fund=fund_short_name, round=round_short_name),
       "isStartButton": true })
     }}
 

--- a/frontend/magic_links/templates/signed_out.html
+++ b/frontend/magic_links/templates/signed_out.html
@@ -26,6 +26,7 @@
     </p>
 {% endif %}
 
+{% if fund and round %}
 <p class="govuk-body">{% trans %}To re-access your account, please click below to request a new link.{% endtrans %}</p>
 
 {{ govukButton({
@@ -33,4 +34,8 @@
     "href" : url_for('magic_links_bp.new', fund=fund, round=round),
     "text": gettext("Request a new link")
 }) }}
+{% else %}
+<p class="govuk-body">{% trans %}To re-access your account, please use the link originally provided in the email sent you.{% endtrans %}</p>
+{% endif %}
+
 {% endblock %}

--- a/tests/test_magic_links.py
+++ b/tests/test_magic_links.py
@@ -371,6 +371,8 @@ class TestMagicLinks(AuthSessionView):
                         mock_account,
                         is_via_magic_link=True,
                         timeout_seconds=3600,
+                        fund="test_fund",
+                        round="test_round",
                     )
                 )
 


### PR DESCRIPTION
Request a new link button was re-directing us to the old get new magic link page which did not have the required fund and round query params. We have now added the fund and round short names as values in the fsd_user_token cookie so that whichever page the user logs out of we are able to pull the appropriate fund and round short names and add them to the url when they click on the request a new link button.
