### PR TITLE
bau-invalid-token-query-params-sign-out

### DIFF
--- a/api/session/auth_session.py
+++ b/api/session/auth_session.py
@@ -75,13 +75,11 @@ class AuthSessionView(MethodView):
             except jwt.PyJWTError:
                 status = "invalid_token"
 
-            # Create query params for signout url if valid token
-            fund_short_name = valid_token.get("fund")
-            round_short_name = valid_token.get("round")
-
-            # If validly issued token, clear the redis store
-            # of the account and link record
+            # If validly issued token: create query params for signout url,
+            # and clear the redis store of the account and link record
             if valid_token and isinstance(valid_token, dict):
+                fund_short_name = valid_token.get("fund")
+                round_short_name = valid_token.get("round")
                 MagicLinkMethods().clear_existing_user_record(
                     valid_token.get("accountId")
                 )


### PR DESCRIPTION
This PR fixes the issue were an invalid token causes auth to break as we cannot get fund and round info from it but need to instead return none for fund and round short names.