### PR TITLE
PAB-328: post-award compatibility

### DIFF
--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -1,6 +1,7 @@
 """Flask configuration."""
 import base64
 import logging
+from collections import namedtuple
 from os import environ
 from os import getenv
 from pathlib import Path
@@ -9,6 +10,10 @@ from config.utils import VcapServices
 from distutils.util import strtobool
 from fsd_utils import CommonConfig
 from fsd_utils import configclass
+from fsd_utils.authentication.config import SupportedApp
+
+
+SafeAppConfig = namedtuple("SafeAppConfig", "login_url logout_endpoint")
 
 
 @configclass
@@ -35,8 +40,8 @@ class DefaultConfig(object):
     # Hostname for this service
     AUTHENTICATOR_HOST = environ.get("AUTHENTICATOR_HOST", "")
     NEW_LINK_ENDPOINT = "/service/magic-links/new"
-    SSO_LOGOUT_ENDPOINT = "/sso/logout"
-    SSO_LOGIN_ENDPOINT = "/sso/login"
+    SSO_LOGOUT_ENDPOINT = "api_sso_routes_SsoView_logout"
+    SSO_LOGIN_ENDPOINT = "api_sso_routes_SsoView_login"
     SSO_POST_SIGN_OUT_URL = (
         AUTHENTICATOR_HOST + "/service/sso/signed-out/signout-request"
     )
@@ -153,6 +158,18 @@ class DefaultConfig(object):
     GET_ROUND_DATA_FOR_FUND_ENDPOINT = (
         FUND_STORE_API_HOST + CommonConfig.ROUND_ENDPOINT
     )
+
+    # Post-award frontend
+    POST_AWARD_FRONTEND_HOST = environ.get("POST_AWARD_FRONTEND_HOST", "")
+    POST_AWARD_FRONTEND_LOGIN_URL = POST_AWARD_FRONTEND_HOST + "/"
+
+    # Safe list of return applications
+    SAFE_RETURN_APPS = {
+        SupportedApp.POST_AWARD_FRONTEND.value: SafeAppConfig(
+            login_url=POST_AWARD_FRONTEND_LOGIN_URL,
+            logout_endpoint="sso_bp.signed_out",
+        )
+    }
 
     """
     Magic Links

--- a/frontend/sso/routes.py
+++ b/frontend/sso/routes.py
@@ -1,6 +1,8 @@
 from config import Config
 from flask import Blueprint
 from flask import render_template
+from flask import request
+from flask import url_for
 
 sso_bp = Blueprint(
     "sso_bp",
@@ -12,11 +14,14 @@ sso_bp = Blueprint(
 
 @sso_bp.route("/signed-out/<status>")
 def signed_out(status):
+    return_app = request.args.get("return_app")
     return (
         render_template(
             "sso_signed_out.html",
             status=status,
-            login_url=Config.SSO_LOGIN_ENDPOINT,
+            login_url=url_for(
+                Config.SSO_LOGIN_ENDPOINT, return_app=return_app
+            ),
         ),
         200,
     )

--- a/frontend/user/routes.py
+++ b/frontend/user/routes.py
@@ -3,6 +3,7 @@ from flask import Blueprint
 from flask import g
 from flask import render_template
 from flask import request
+from flask import url_for
 from fsd_utils.authentication.decorators import login_requested
 
 user_bp = Blueprint(
@@ -41,8 +42,8 @@ def user():
             "user.html",
             roles_required=roles_required,
             logged_in_user=logged_in_user,
-            login_url=Config.SSO_LOGIN_ENDPOINT,
-            logout_url=Config.SSO_LOGOUT_ENDPOINT,
+            login_url=url_for(Config.SSO_LOGIN_ENDPOINT),
+            logout_url=url_for(Config.SSO_LOGOUT_ENDPOINT),
             support_mailbox=Config.SUPPORT_MAILBOX_EMAIL,
         ),
         status_code,

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -88,6 +88,13 @@ paths:
       summary: Microsoft Authentication Library Login redirect
       description: Redirect to Microsoft Authentication Login Flow
       operationId: api.sso.routes.SsoView.login
+      parameters:
+        - in: query
+          name: return_app
+          description: Optional parameter to specify the return app
+          required: false
+          schema:
+            type: string
       responses:
         302:
           description: SUCCESS - Redirect to Microsoft Authentication Login Flow
@@ -140,6 +147,13 @@ paths:
       summary: Signs out a user
       description: Signs out a user who has authenticated via a magic link
       operationId: api.AuthSessionView.clear_session
+      parameters:
+        - in: query
+          name: return_app
+          description: Optional parameter to specify the return app
+          required: false
+          schema:
+            type: string
       responses:
         302:
           description: SUCCESS - Active user session cleared and redirected to the signed out page

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -180,7 +180,7 @@ flipper-client==1.3.2
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
-funding-service-design-utils==2.0.1
+funding-service-design-utils==2.0.2
     # via -r requirements.txt
 gitdb==4.0.9
     # via gitpython

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@
 #   FSD Utils
 #-----------------------------------
 
-funding-service-design-utils>=2.0.1,<2.1.0
+funding-service-design-utils>=2.0.2,<2.1.0
 
 requests
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -101,7 +101,7 @@ flask-wtf==1.0.0
     # via -r requirements.in
 flipper-client==1.3.2
     # via funding-service-design-utils
-funding-service-design-utils==2.0.1
+funding-service-design-utils==2.0.2
     # via -r requirements.in
 govuk-frontend-jinja==2.3.0
     # via -r requirements.in


### PR DESCRIPTION
https://trello.com/c/tQ3rDYzh/328-implement-authentication-changes-into-front-end-auth-utils-and-docker-runner

### Change description
Enables other FSD applications (namely for now, post-award-frontend) to make use of the SSO and Session capability of authenticator. This is enabled by passing a `return_app` query param to authenticator when requesting SSO authentication, so that the app can return back to other applications other than pre-award-assessment. These apps are defined in config and map to return URLs and authorisation BPs.

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
