### PR TITLE
FS-2304: Local SSO

### DIFF
--- a/models/account.py
+++ b/models/account.py
@@ -1,10 +1,12 @@
 from dataclasses import dataclass
 from typing import List
 
+import config
 from config import Config
 from flask import current_app
 from fsd_utils.authentication.config import azure_ad_role_map
 from fsd_utils.config.notify_constants import NotifyConstants
+from models.data import get_account_data
 from models.data import get_data
 from models.data import get_round_data
 from models.data import post_data
@@ -112,11 +114,13 @@ class AccountMethods(Account):
         cleaned_roles = []
         if isinstance(roles, List):
             cleaned_roles = [azure_ad_role_map[role] for role in roles]
+        if config.FLASK_ENV == "development":
+            account = get_account_data(email)
+            cleaned_roles = account.get("roles")
         if len(cleaned_roles) == 0:
             current_app.logger.error(
                 f"account id: {id} has not been assigned any roles"
             )
-
         params = {
             "email_address": email,
             "azure_ad_subject_id": azure_ad_subject_id,
@@ -235,11 +239,11 @@ class AccountMethods(Account):
             )
             notification_content.update(
                 {
-                    NotifyConstants.MAGIC_LINK_URL_FIELD: new_link_json.get(  # noqa
+                    NotifyConstants.MAGIC_LINK_URL_FIELD: new_link_json.get(
                         "link"
                     )
                 }
-            )
+            )  # noqa
             current_app.logger.debug(
                 f"Magic Link URL: {new_link_json.get('link')}"
             )

--- a/models/data.py
+++ b/models/data.py
@@ -132,3 +132,12 @@ def get_round_data_fail_gracefully(fund_id, round_id, use_short_name=False):
     # return valid Round object with no values so we
     # know we've failed and can handle in templates appropriately
     return Round("", "", "", "", "", "", "", "", "", "", "", "", "", "")
+
+
+def get_account_data(email: str):
+    url = Config.ACCOUNT_STORE_API_HOST + Config.ACCOUNTS_ENDPOINT
+    params = {
+        "email_address": email,
+    }
+    response = get_data(endpoint=url, params=params)
+    return response


### PR DESCRIPTION
This ticket resolves the issues of not being able to login locally via sso thereby blocking testing of sso on local environments.

- session[user] token had no key called roles, therefore whenever the update_account() method was called it kept resetting the roles for the user trying to log in.
- We can see that this only happens locally and not in dev or test environments where we are using the exact same azure test tenant.
- This suggests that the session[user] token in other environments does include a key called roles which grabs the values from the azure ad, but for some reason does not exist when running locally.
- to bypass this, this PR introduces changes that checks whether we are on the local development environment and then sets the roles as found in the account store for the user trying to login rather than setting roles found from the azure ad. 
