### PR TITLE
Fs 2825 dynamic authenticator help email

### DIFF
--- a/frontend/magic_links/routes.py
+++ b/frontend/magic_links/routes.py
@@ -89,6 +89,7 @@ def landing(link_id):
             submission_deadline=submission_deadline,
             fund_name=fund_name,
             round_title=round_data.title,
+            contact_email=round_data.contact_email,
             fund_short_name=fund_short_name,
             round_short_name=round_short_name,
             all_questions_url=Config.APPLICATION_ALL_QUESTIONS_URL.format(

--- a/frontend/magic_links/templates/landing.html
+++ b/frontend/magic_links/templates/landing.html
@@ -57,7 +57,7 @@
     <h2 class="govuk-heading-m">{% trans %}Get help{% endtrans %}</h2>
     <p class="govuk-body">
       {% trans %}If you have questions about the form or the fund, email us at{% endtrans %}
-      <a class="govuk-link" href="mailto:{{contact_email}}">{{contact_email}}</a>.
+      <a class="govuk-link" href="mailto:{{ contact_email }}">{{ contact_email }}</a>.
     </p>
     <h2 class="govuk-heading-m">{% trans %}How we'll use your information{% endtrans %}</h2>
     <p class="govuk-body">

--- a/frontend/magic_links/templates/landing.html
+++ b/frontend/magic_links/templates/landing.html
@@ -57,7 +57,7 @@
     <h2 class="govuk-heading-m">{% trans %}Get help{% endtrans %}</h2>
     <p class="govuk-body">
       {% trans %}If you have questions about the form or the fund, email us at{% endtrans %}
-      <a class="govuk-link" href="mailto:COF@levellingup.gov.uk">COF@levellingup.gov.uk</a>.
+      <a class="govuk-link" href="mailto:{{contact_email}}">{{contact_email}}</a>.
     </p>
     <h2 class="govuk-heading-m">{% trans %}How we'll use your information{% endtrans %}</h2>
     <p class="govuk-body">

--- a/tests/test_magic_links.py
+++ b/tests/test_magic_links.py
@@ -267,6 +267,7 @@ class TestMagicLinks(AuthSessionView):
             mock_round.configure_mock(deadline="2023-01-30T00:00:01")
             mock_round.configure_mock(title="r2w3")
             mock_round.configure_mock(short_name="r2w3")
+            mock_round.configure_mock(contact_email="test@outlook.com")
             mock_get_round_data.return_value = mock_round
 
             # use magic link landing but unauthorised
@@ -275,6 +276,7 @@ class TestMagicLinks(AuthSessionView):
             assert landing_response.status_code == 200
             assert b"How to complete your application" in landing_response.data
             assert b"Continue" in landing_response.data
+            assert b"mailto:test@outlook.com" in landing_response.data
 
             # use link
             use_link_response = flask_test_client.get(use_endpoint)


### PR DESCRIPTION
A fix to remove hardcoded email for COF, instead load contact email dynamically based on round information from fund store.

### Change description
OLD
<img width="457" alt="image" src="https://github.com/communitiesuk/funding-service-design-authenticator/assets/95699325/f63ab0f8-8bb0-4644-a6f4-11c6f05d930d">

NEW
<img width="457" alt="image" src="https://github.com/communitiesuk/funding-service-design-authenticator/assets/95699325/76a37c4c-5341-476d-94d3-6eb9f8162cc9">


- [X] Unit tests and other appropriate tests added or updated
- [X] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
pytest


### Screenshots of UI changes (if applicable)
