### PR TITLE
BAU: Set include manifest to true

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
       apply_network_policy: true
       run_performance_tests: true
       run_e2e_tests: true
+      include_manifest: true
     secrets:
       CF_API: ${{secrets.CF_API}}
       CF_ORG: ${{secrets.CF_ORG}}


### PR DESCRIPTION
### Change description
Follow-up to: https://github.com/communitiesuk/funding-service-design-authenticator/pull/158 hypothesis is this didn't work because the manifest env vars weren't being set as this was set to false by default


### How to test
Can test post-merge with test deployment.

### Screenshots of UI changes (if applicable)
