### PR TITLE
Making privacy notice url dynamic

### DIFF
--- a/app.py
+++ b/app.py
@@ -126,6 +126,8 @@ def create_app() -> Flask:
             cookie_policy_url=Config.APPLICANT_FRONTEND_COOKIE_POLICY_URL,
             contact_us_url=Config.APPLICANT_FRONTEND_CONTACT_US_URL
             + f"?fund={request.args.get('fund', '')}&round={request.args.get('round', '')}",
+            privacy_url=Config.APPLICANT_FRONTEND_PRIVACY_URL
+            + f"?fund={request.args.get('fund', '')}&round={request.args.get('round', '')}",
         )
 
     @flask_app.context_processor

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -137,6 +137,7 @@ class DefaultConfig(object):
         APPLICANT_FRONTEND_HOST + "/cookie_policy"
     )
     APPLICANT_FRONTEND_CONTACT_US_URL = APPLICANT_FRONTEND_HOST + "/contact_us"
+    APPLICANT_FRONTEND_PRIVACY_URL = APPLICANT_FRONTEND_HOST + "/privacy"
     APPLICATION_ALL_QUESTIONS_URL = (
         APPLICANT_FRONTEND_HOST
         + "/all_questions/{fund_short_name}/{round_short_name}"

--- a/frontend/templates/footer.html
+++ b/frontend/templates/footer.html
@@ -5,7 +5,7 @@
             'visuallyHiddenTitle': 'Support links',
             'items': [
                 {
-                    'href': 'https://www.gov.uk/government/publications/community-ownership-fund-privacy-notice/community-ownership-fund-privacy-notice',
+                    'href': privacy_url,
                     'text': gettext('Privacy')
 
                 },


### PR DESCRIPTION
Part of night shelter config work, making hte url for the privacy notice dynamic (passing in fund and round)


### Change description
Added privacy notice url to the injected values in create_app, rather than hardcoding tot he COF notice.

- [n/a] Unit tests and other appropriate tests added or updated
- [n/a] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Navigate to any page in the authenticator and the url for the privacy notice in the footer should have querystring params for the fund and round


### Screenshots of UI changes (if applicable)
