### PR TITLE
BAU: Auto redirect to magic link on development

### DIFF
--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -46,6 +46,8 @@ class DefaultConfig(object):
         AUTHENTICATOR_HOST + "/service/sso/signed-out/signout-request"
     )
 
+    AUTO_REDIRECT_LOGIN = False
+
     """
     Azure Configuration
     """

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -76,6 +76,8 @@ class DevelopmentConfig(Config):
         "NOTIFICATION_SERVICE_HOST", "notification_service"
     )
 
+    AUTO_REDIRECT_LOGIN = True
+
     DISABLE_NOTIFICATION_SERVICE = (
         False  # Toggle on if you have no notify api key.
     )

--- a/frontend/magic_links/routes.py
+++ b/frontend/magic_links/routes.py
@@ -131,11 +131,18 @@ def new():
     form = EmailForm(data=form_data)
     if form.validate_on_submit():
         try:
-            AccountMethods.get_magic_link(
+            created_link = AccountMethods.get_magic_link(
                 email=form.data.get("email"),
                 fund_short_name=fund_short_name,
                 round_short_name=round_short_name,
             )
+
+            if Config.AUTO_REDIRECT_LOGIN:
+                current_app.logger.info(
+                    f"Auto redirecting to magic link:  {created_link}"
+                )
+                return redirect(created_link)
+
             return redirect(
                 url_for(
                     "magic_links_bp.check_email",

--- a/models/account.py
+++ b/models/account.py
@@ -249,7 +249,8 @@ class AccountMethods(Account):
                 account.email,
                 notification_content,
             )
-            return True
+
+            return new_link_json.get("link")
         current_app.logger.error(
             f"Could not create an account ({account}) for email '{email}'"
         )


### PR DESCRIPTION
### Change description

- Whenever `AUTO_REDIRECT_LOGIN` is set to `True`, we auto redirect to the magic link
- Only set to `True` in development, shouldn't be set to `True` on prod/uat, etc.

--- 

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines


### How to test

- Pull branch locally
- Try to login to the application via magic link