### PR TITLE
FS-2990 & FS-2989: Update utils for devolved auth and multi fund

### DIFF
--- a/frontend/default/routes.py
+++ b/frontend/default/routes.py
@@ -24,7 +24,7 @@ def not_found(error):
     return render_template("404.html", round_data=round_data), 404
 
 
-@default_bp.errorhandler(500)
+# @default_bp.errorhandler(500)
 def internal_server_error(error):
     current_app.logger.error(f"Encountered 500: {error}")
     return (

--- a/models/account.py
+++ b/models/account.py
@@ -115,7 +115,7 @@ class AccountMethods(Account):
         cleaned_roles = []
         if isinstance(roles, List):
             cleaned_roles = [azure_ad_role_map[role] for role in roles]
-        if config.FLASK_ENV == "development":
+        if config.FLASK_ENV == "development" and not any(cleaned_roles):
             account = get_account_data(email)
             cleaned_roles = account.get("roles")
         if len(cleaned_roles) == 0:

--- a/models/account.py
+++ b/models/account.py
@@ -111,6 +111,7 @@ class AccountMethods(Account):
         url = Config.ACCOUNT_STORE_API_HOST + Config.ACCOUNT_ENDPOINT.format(
             account_id=id
         )
+        current_app.logger.info(f"Mapping roles: {roles}")
         cleaned_roles = []
         if isinstance(roles, List):
             cleaned_roles = [azure_ad_role_map[role] for role in roles]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -182,7 +182,7 @@ flipper-client==1.3.2
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
-funding-service-design-utils @ git+https://github.com/communitiesuk/funding-service-design-utils.git@tferns-fs-2990
+funding-service-design-utils==2.0.8
     # via -r requirements.txt
 gitdb==4.0.9
     # via gitpython

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,7 +32,9 @@ babel==2.10.3
 bandit==1.7.4
     # via -r requirements-dev.in
 beautifulsoup4==4.12.2
-    # via -r requirements-dev.in
+    # via
+    #   -r requirements-dev.in
+    #   -r requirements.txt
 black==22.10.0
     # via -r requirements-dev.in
 blinker==1.6.2
@@ -450,7 +452,9 @@ sniffio==1.2.0
 sortedcontainers==2.4.0
     # via trio
 soupsieve==2.4.1
-    # via beautifulsoup4
+    # via
+    #   -r requirements.txt
+    #   beautifulsoup4
 sqlalchemy==1.4.42
     # via
     #   -r requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -172,7 +172,7 @@ flipper-client==1.3.2
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
-funding-service-design-utils==2.0.2
+funding-service-design-utils @ git+https://github.com/communitiesuk/funding-service-design-utils.git@tferns-fs-2990
     # via -r requirements.txt
 gitdb==4.0.9
     # via gitpython

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@
 #   FSD Utils
 #-----------------------------------
 
-funding-service-design-utils>=2.0.5,<2.1.0
+funding-service-design-utils>=2.0.8,<2.1.0
 
 requests
 

--- a/requirements.in
+++ b/requirements.in
@@ -55,3 +55,8 @@ connexion==2.14.2
 swagger-ui-bundle
 openapi-spec-validator
 prance
+
+#-----------------------------------
+#   Other
+#-----------------------------------
+beautifulsoup4==4.12.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -101,7 +101,7 @@ flask-wtf==1.0.0
     # via -r requirements.in
 flipper-client==1.3.2
     # via funding-service-design-utils
-funding-service-design-utils @ git+https://github.com/communitiesuk/funding-service-design-utils.git@tferns-fs-2990
+funding-service-design-utils==2.0.8
     # via -r requirements.in
 govuk-frontend-jinja==2.3.0
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,8 @@ attrs==21.4.0
     # via jsonschema
 babel==2.10.3
     # via flask-babel
+beautifulsoup4==4.12.2
+    # via -r requirements.in
 blinker==1.6.2
     # via sentry-sdk
 boto3==1.26.131
@@ -227,6 +229,8 @@ six==1.16.0
     #   python-consul
     #   python-dateutil
     #   thrift
+soupsieve==2.4.1
+    # via beautifulsoup4
 sqlalchemy==1.4.42
     # via
     #   -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -99,7 +99,7 @@ flask-wtf==1.0.0
     # via -r requirements.in
 flipper-client==1.3.2
     # via funding-service-design-utils
-funding-service-design-utils==2.0.2
+funding-service-design-utils @ git+https://github.com/communitiesuk/funding-service-design-utils.git@tferns-fs-2990
     # via -r requirements.in
 govuk-frontend-jinja==2.3.0
     # via -r requirements.in

--- a/testing/mocks/mocks/msal.py
+++ b/testing/mocks/mocks/msal.py
@@ -10,7 +10,7 @@ id_token_claims = {
     "id": 123,
     "sub": "abc",
     "preferred_username": "sso@example.com",
-    "roles": ["LeadAssessor", "Assessor", "Commenter"],
+    "roles": ["COF_Lead_Assessor", "Assessor", "Commenter"],
 }
 
 # Mocked accounts response from msal get_accounts method
@@ -22,7 +22,7 @@ expected_fsd_user_token_claims = {
     "azureAdSubjectId": "abc",
     "email": "sso@example.com",
     "fullName": "Test User SSO",
-    "roles": ["LEAD_ASSESSOR", "ASSESSOR", "COMMENTER"],
+    "roles": ["COF_LEAD_ASSESSOR", "COF_ASSESSOR", "COF_COMMENTER"],
 }
 
 # Role-less fsd-user-token claims

--- a/tests/api_data/put_endpoint_data.json
+++ b/tests/api_data/put_endpoint_data.json
@@ -1,14 +1,14 @@
 {
   "account_store/accounts/usersso": {
-    "email_address=sso%40example.com&azure_ad_subject_id=abc&full_name=Test+User+SSO&roles=%5B%27LEAD_ASSESSOR%27%2C+%27ASSESSOR%27%2C+%27COMMENTER%27%5D": {
+    "email_address=sso%40example.com&azure_ad_subject_id=abc&full_name=Test+User+SSO&roles=%5B%27COF_LEAD_ASSESSOR%27%2C+%27COF_ASSESSOR%27%2C+%27COF_COMMENTER%27%5D": {
       "account_id": "usersso",
       "full_name": "Test User SSO",
       "azure_ad_subject_id": "abc",
       "email_address": "sso@example.com",
       "roles": [
-        "LEAD_ASSESSOR",
-        "ASSESSOR",
-        "COMMENTER"
+        "COF_LEAD_ASSESSOR",
+        "COF_ASSESSOR",
+        "COF_COMMENTER"
       ]
     },
     "email_address=sso%40example.com&azure_ad_subject_id=abc&full_name=Test+User+SSO&roles=%5B%5D": {

--- a/tests/test_magic_links.py
+++ b/tests/test_magic_links.py
@@ -399,7 +399,7 @@ class TestMagicLinks(AuthSessionView):
             email="example@admin.com",
             azure_ad_subject_id="fg4FtjR5he365ir5h4k34_43ck5454ddsrtDe47",
             full_name="Joe Smith",
-            roles=["LEAD_ASSESSOR", "ASSESSOR", "COMMENTER"],
+            roles=["COF_LEAD_ASSESSOR", "COF_ASSESSOR", "COF_COMMENTER"],
         )
 
         with app.app_context():

--- a/tests/test_signout.py
+++ b/tests/test_signout.py
@@ -155,7 +155,7 @@ class TestSignout:
             "accountId": "test-user",
             "email": "test@example.com",
             "fullName": "Test User",
-            "roles": ["LEAD_ASSESSOR", "ASSESSOR", "COMMENTER"],
+            "roles": ["COF_LEAD_ASSESSOR", "COF_ASSESSOR", "COF_COMMENTER"],
         }
 
         token = create_token(test_payload)
@@ -192,13 +192,13 @@ class TestSignout:
             "accountId": "test-user",
             "email": "test@example.com",
             "fullName": "Test User",
-            "roles": ["LEAD_ASSESSOR", "ASSESSOR", "COMMENTER"],
+            "roles": ["COF_LEAD_ASSESSOR", "COF_ASSESSOR", "COF_COMMENTER"],
         }
 
         token = create_token(test_payload)
         flask_test_client.set_cookie("localhost", "fsd_user_token", token)
 
-        endpoint = "/service/user?roles_required=assessor|commenter"
+        endpoint = "/service/user?roles_required=cof_assessor|cof_commenter"
         response = flask_test_client.get(endpoint)
         assert response.status_code == 200
         assert (


### PR DESCRIPTION
### Change description

- Add a check for local development, we use roles from the database instead of from Azure AD.
- Update utils so `azure_ad_role_map` changes are picked up

---

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines

### Other related PRs:

https://github.com/communitiesuk/funding-service-design-utils/pull/85
https://github.com/communitiesuk/funding-service-design-account-store/pull/96
https://github.com/communitiesuk/funding-service-design-assessment-store/pull/198
https://github.com/communitiesuk/funding-service-design-assessment/pull/275