### PR TITLE
FS-3024: Don't fail on unknown roles

### DIFF
--- a/models/account.py
+++ b/models/account.py
@@ -113,7 +113,11 @@ class AccountMethods(Account):
         )
         cleaned_roles = []
         if isinstance(roles, List):
-            cleaned_roles = [azure_ad_role_map[role] for role in roles]
+            cleaned_roles = [
+                azure_ad_role_map[role]
+                for role in roles
+                if role in azure_ad_role_map
+            ]
         if config.FLASK_ENV == "development":
             account = get_account_data(email)
             cleaned_roles = account.get("roles")


### PR DESCRIPTION
Have been testing `FS-3024` locally, but now want to test on the test env, due to all envs using the same Azure AD, and the new fund specific role & devolved authority changes, an error has been popping up when I try to login: https://funding-service-design-team-dl.sentry.io/issues/4270641612/?project=4503919190016000&query=is%3Aunresolved&referrer=issue-stream&stream_index=0

This is a temporary fix, so we don't hard fail on roles that we don't know.  

Note that https://github.com/communitiesuk/funding-service-design-authenticator/pull/169 will be updated to account for this in the future, this is just a fix so I can test in the test env.