### PR TITLE
add USE_PRE_EXISTING_ACCOUNT_ROLES envvar

### DIFF
--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -14,6 +14,7 @@ class DevelopmentConfig(Config):
     SESSION_COOKIE_NAME = "session_cookie"
     FLASK_ENV = "development"
     COOKIE_DOMAIN = None
+    USE_PRE_EXISTING_ACCOUNT_ROLES = False
 
     # Logging
     FSD_LOG_LEVEL = logging.DEBUG

--- a/models/account.py
+++ b/models/account.py
@@ -114,7 +114,7 @@ class AccountMethods(Account):
         cleaned_roles = []
         if isinstance(roles, List):
             cleaned_roles = [azure_ad_role_map[role] for role in roles]
-        if config.FLASK_ENV == "development":
+        if hasattr(Config, 'USE_PRE_EXISTING_ACCOUNT_ROLES') and Config.USE_PRE_EXISTING_ACCOUNT_ROLES:
             account = get_account_data(email)
             cleaned_roles = account.get("roles")
         if len(cleaned_roles) == 0:

--- a/models/account.py
+++ b/models/account.py
@@ -114,7 +114,10 @@ class AccountMethods(Account):
         cleaned_roles = []
         if isinstance(roles, List):
             cleaned_roles = [azure_ad_role_map[role] for role in roles]
-        if hasattr(Config, 'USE_PRE_EXISTING_ACCOUNT_ROLES') and Config.USE_PRE_EXISTING_ACCOUNT_ROLES:
+        if (
+            hasattr(Config, "USE_PRE_EXISTING_ACCOUNT_ROLES")
+            and Config.USE_PRE_EXISTING_ACCOUNT_ROLES
+        ):
             account = get_account_data(email)
             cleaned_roles = account.get("roles")
         if len(cleaned_roles) == 0:


### PR DESCRIPTION
Patch to: https://github.com/communitiesuk/funding-service-design-authenticator/pull/155

Before this PR, when a user is running authenticator in a development environment, it would bypass the roles provided by AzureAD in favour of those pre-existing in the account store database. 
This has the following issues:
- If the account had no roles this route woulf fail
- If the account had the wrong roles in the account store this would require manually changing the roles (instead of just inheriting the correct ones from AD)
- The account store and AD for an account were not synchronized as they would be in dev and test
- We could not replicate the authentication flow in development.

This patch introduces a new environment variable (USE_PRE_EXISTING_ACCOUNT_ROLES) that allows users the option to bypass role assignment via Azure AD in favour of the pre-existing roles in the account store, without forcing this logic path for anyone using the development environment. 