### PR TITLE
add post-award Submit host to manifest

### DIFF
--- a/copilot/fsd-authenticator/manifest.yml
+++ b/copilot/fsd-authenticator/manifest.yml
@@ -50,6 +50,7 @@ variables:
   ACCOUNT_STORE_API_HOST: "http://fsd-account-store:8080"
   AUTHENTICATOR_HOST: "https://authenticator.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
   POST_AWARD_FRONTEND_HOST: "https://find-monitoring-data.${data.cloudfoundry_domain.workspace.name}"
+  POST_AWARD_SUBMIT_HOST: "https://submit-monitoring-data.${data.cloudfoundry_domain.workspace.name}"
   APPLICATION_STORE_API_HOST: "http://fsd-application-store:8080"
   NOTIFICATION_SERVICE_HOST: "http://fsd-notification:8080"
   APPLICANT_FRONTEND_HOST: "https://frontend.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"


### PR DESCRIPTION
### Change description
- adds the post-award Submit host to manifest envars so that Authenticator can redirect to the Submit tool

- [X] Unit tests and other appropriate tests added or updated
- [X] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
