### PR TITLE
BAU: Include fund & round in redirect

### DIFF
--- a/api/magic_links/routes.py
+++ b/api/magic_links/routes.py
@@ -89,13 +89,14 @@ class MagicLinksView(MagicLinkMethods, MethodView):
             # else if no link exists (or it has been used)
             # but the user is already logged in
             # then redirect them to the global redirect url
+            frontend_account_url = f"{Config.MAGIC_LINK_REDIRECT_URL}?fund={fund_short_name}&round={round_short_name}"
             current_app.logger.warn(
                 f"The magic link with hash: '{link_hash}' has already been"
                 f" used but the user with account_id: '{g.account_id}' is"
                 " logged in, redirecting to"
-                f" '{Config.MAGIC_LINK_REDIRECT_URL}'."
+                f" '{frontend_account_url}'."
             )
-            return redirect(Config.MAGIC_LINK_REDIRECT_URL)
+            return redirect(frontend_account_url)
         return redirect(
             url_for(
                 "magic_links_bp.invalid",

--- a/api/magic_links/routes.py
+++ b/api/magic_links/routes.py
@@ -1,4 +1,5 @@
 import json
+import urllib.parse
 from datetime import datetime
 
 from api.responses import error_response
@@ -89,7 +90,11 @@ class MagicLinksView(MagicLinkMethods, MethodView):
             # else if no link exists (or it has been used)
             # but the user is already logged in
             # then redirect them to the global redirect url
-            frontend_account_url = f"{Config.MAGIC_LINK_REDIRECT_URL}?fund={fund_short_name}&round={round_short_name}"
+            frontend_account_url = (
+                f"{Config.MAGIC_LINK_REDIRECT_URL}"
+                f"?fund={urllib.parse.quote(fund_short_name)}"
+                f"&round={urllib.parse.quote(round_short_name)}"
+            )
             current_app.logger.warn(
                 f"The magic link with hash: '{link_hash}' has already been"
                 f" used but the user with account_id: '{g.account_id}' is"

--- a/api/magic_links/routes.py
+++ b/api/magic_links/routes.py
@@ -92,8 +92,8 @@ class MagicLinksView(MagicLinkMethods, MethodView):
             # then redirect them to the global redirect url
             frontend_account_url = (
                 f"{Config.MAGIC_LINK_REDIRECT_URL}"
-                f"?fund={urllib.parse.quote(fund_short_name)}"
-                f"&round={urllib.parse.quote(round_short_name)}"
+                f"?fund={urllib.parse.quote(fund_short_name) if fund_short_name else ''}"
+                f"&round={urllib.parse.quote(round_short_name) if round_short_name else ''}"
             )
             current_app.logger.warn(
                 f"The magic link with hash: '{link_hash}' has already been"

--- a/frontend/default/routes.py
+++ b/frontend/default/routes.py
@@ -1,3 +1,5 @@
+import traceback
+
 from config import Config
 from flask import Blueprint
 from flask import current_app
@@ -26,7 +28,9 @@ def not_found(error):
 
 @default_bp.errorhandler(500)
 def internal_server_error(error):
-    current_app.logger.error(f"Encountered 500: {error}")
+    error_message = f"Encountered 500: {error}"
+    stack_trace = traceback.format_exc()
+    current_app.logger.error(f"{error_message}\n{stack_trace}")
     return (
         render_template(
             "500.html",


### PR DESCRIPTION
### Change description

- In scenarios where a user clicks "continue" on a magic link they've already claimed
- If they still have a token in their browser, we re-direct them to the "/account" page
- This change makes it so we re-direct them to the specific fund/round they're trying to continue to

---

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines


### How to test

- Request a magic link for [DPIF](https://fsd:fsd@authenticator.uat.gids.dev/service/magic-links/new?fund=dpif&round=r2)
- Open the magic link from your email and hit continue
- You should be on the DPIF specific account page, and can start an application
- Hit back on your browser then continue again
- You should be on the DPIF specific account page, and can start an application (used to be on just /account)
