### PR TITLE
BAU: Fix truthy check on roles

### DIFF
--- a/api/sso/routes.py
+++ b/api/sso/routes.py
@@ -101,7 +101,7 @@ class SsoView(MethodView):
             azure_ad_subject_id=session["user"].get("sub"),
             email=session["user"].get("preferred_username"),
             full_name=session["user"].get("name"),
-            roles=session["user"].get("roles"),
+            roles=session["user"].get("roles") or [],
         )
 
         redirect_url = (

--- a/models/account.py
+++ b/models/account.py
@@ -91,7 +91,7 @@ class AccountMethods(Account):
         email: str,
         azure_ad_subject_id: str,
         full_name: str,
-        roles: List[str],
+        roles: list[str],
     ) -> Account | None:
         """
         Get an account corresponding to an email_address
@@ -111,10 +111,10 @@ class AccountMethods(Account):
             account_id=id
         )
 
-        if config.FLASK_ENV == "development" and len(roles) == 0:
+        if config.FLASK_ENV == "development" and roles:
             account = get_account_data(email)
             roles = account.get("roles")
-        if len(roles) == 0:
+        if roles:
             current_app.logger.error(
                 f"account id: {id} has not been assigned any roles"
             )
@@ -122,7 +122,7 @@ class AccountMethods(Account):
             "email_address": email,
             "azure_ad_subject_id": azure_ad_subject_id,
             "full_name": full_name,
-            "roles": roles,
+            "roles": roles or [],
         }
         response = put_data(url, params)
         if response and "account_id" in response:
@@ -157,7 +157,7 @@ class AccountMethods(Account):
         email: str,
         azure_ad_subject_id: str,
         full_name: str,
-        roles: List[str],
+        roles: list[str],
     ):
         # Check to see if account already exists by azure_id or email
         account = AccountMethods.get_account(

--- a/models/account.py
+++ b/models/account.py
@@ -111,10 +111,10 @@ class AccountMethods(Account):
             account_id=id
         )
 
-        if config.FLASK_ENV == "development" and roles:
+        if config.FLASK_ENV == "development" and not roles:
             account = get_account_data(email)
             roles = account.get("roles")
-        if roles:
+        if not roles:
             current_app.logger.error(
                 f"account id: {id} has not been assigned any roles"
             )


### PR DESCRIPTION
### Change description

- When an account/user has no roles, the "roles" key isnt available on the claims coming back from azure
- So we default to an empty list if that is the case, instead of `None`
- Changes length checks to just truthy, which will work on empty or populated list 

---

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines
