### PR TITLE
BAU: use manifest for authenticator

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
       apply_network_policy: true
       run_performance_tests: true
       run_e2e_tests: true
+      include_manifest: true
     secrets:
       CF_API: ${{secrets.CF_API}}
       CF_ORG: ${{secrets.CF_ORG}}

--- a/manifest-dev.yml
+++ b/manifest-dev.yml
@@ -31,7 +31,6 @@ applications:
     - funding-service-magic-links-dev
     - logit-ssl-drain
   routes:
-    - route: authenticator.dev.fundingservice.co.uk
     - route: authenticator2.dev.gids.dev
   health-check-http-endpoint: /healthcheck
   health-check-type: http

--- a/manifest-test.yml
+++ b/manifest-test.yml
@@ -32,7 +32,6 @@ applications:
     - funding-service-magic-links-test
     - logit-ssl-drain
   routes:
-    - route: authenticator.test.fundingservice.co.uk
     - route: authenticator2.test.gids.dev
   health-check-http-endpoint: /healthcheck
   health-check-type: http


### PR DESCRIPTION
### Change description
Previously authenticator was not picking changes in the manifest, as the `include_manifest` flag on the workflow was set to false.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Env Vars should be set on Test post-merge/deployment on test


### Screenshots of UI changes (if applicable)
