### PR TITLE
FS-3890 making migration banner an env var

### DIFF
--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -284,4 +284,4 @@ class DefaultConfig(object):
 
     BABEL_TRANSLATION_DIRECTORIES = "frontend/translations"
 
-    MIGRATION_BANNER_ENABLED = True
+    MIGRATION_BANNER_ENABLED = getenv("MIGRATION_BANNER_ENABLED", False)

--- a/copilot/fsd-authenticator/manifest.yml
+++ b/copilot/fsd-authenticator/manifest.yml
@@ -97,8 +97,7 @@ environments:
       response_time: 2s
   prod:
     http:
-      alias: authenticator.prod.access-funding.levellingup.gov.uk
-      # alias: ["authenticator.prod.access-funding.levellingup.gov.uk", "authenticator.access-funding.levellingup.gov.uk"] # For go live
+      alias: ["authenticator.prod.access-funding.levellingup.gov.uk", "authenticator.access-funding.levellingup.gov.uk"]
     variables:
       ALLOW_ASSESSMENT_LOGIN_VIA_MAGIC_LINK: false
       COOKIE_DOMAIN: ".levellingup.gov.uk"

--- a/copilot/fsd-authenticator/manifest.yml
+++ b/copilot/fsd-authenticator/manifest.yml
@@ -81,7 +81,7 @@ environments:
       ALLOW_ASSESSMENT_LOGIN_VIA_MAGIC_LINK: true
   uat:
     http:
-      alias: ["authenticator.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk", "authenticatoruat.access-funding.test.levellingup.gov.uk"]
+      alias: "authenticator.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
     variables:
       ALLOW_ASSESSMENT_LOGIN_VIA_MAGIC_LINK: true
     count:


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3890

### Change description
Add the true DNS entry alongside the .prod. variant.
Ensure the migration banner flag is a config variable, not hardcoded, and make it false.

- [n/a] Unit tests and other appropriate tests added or updated
- [n/a] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

