### PR TITLE
correcting paths for push triggers

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -25,7 +25,14 @@ on:
   push:
     paths:
       - '!**/README.md'
-      - 'app/**'
+      - '!docs/**'
+      - 'api/**'
+      - 'config/**'
+      - 'frontend/**'
+      - 'models/**'
+      - 'openapi/**'
+      - 'run/**'
+      - 'security/**'
       - 'tests/**'
       - 'requirements-dev.in'
       - 'requirements-dev.txt'


### PR DESCRIPTION
Correcting the list of paths that trigger a deployment as authenitcator is structured differently to other apps