### PR TITLE
BAU: Fix as_dict argument of method

### DIFF
--- a/frontend/magic_links/routes.py
+++ b/frontend/magic_links/routes.py
@@ -66,7 +66,7 @@ def landing(link_id):
     round_short_name = request.args.get("round")
 
     fund_data = FundMethods.get_fund(fund_short_name)
-    round_data = get_round_data(fund_short_name, round_short_name, as_dict=True)
+    round_data = get_round_data(fund_short_name, round_short_name)
 
     if not bool(fund_data and round_data):
         current_app.logger.warn("Fund and round information missing from query string")

--- a/models/account.py
+++ b/models/account.py
@@ -201,7 +201,6 @@ class AccountMethods(Account):
             round_for_fund = get_round_data(
                 fund_short_name,
                 round_short_name,
-                as_dict=True,
             )
 
             notification_content = {

--- a/models/data.py
+++ b/models/data.py
@@ -104,7 +104,7 @@ def get_round_data(
         "use_short_name": True,
     }
     response = get_data(endpoint=url, params=params)
-    if as_dict and response:
+    if not as_dict and response:
         return Round.from_dict(response)
     else:
         return response


### PR DESCRIPTION
- For some reason, providing `as_dict` as `False` (default) was returning a dict, contrary to the name... 
- Fixed function implementation and usages to accurately return a dict based on the argument name