### PR TITLE
FS-4071: Show "contact_us" or email depending on fund

### DIFF
--- a/frontend/magic_links/routes.py
+++ b/frontend/magic_links/routes.py
@@ -101,6 +101,7 @@ def landing(link_id):
             application_guidance=app_guidance,
             round_prospectus=round_prospectus,
             migration_banner_enabled=Config.MIGRATION_BANNER_ENABLED,
+            link_to_contact_us_page=round_data.reference_contact_page_over_email,
         )
     return redirect(
         url_for(

--- a/frontend/magic_links/templates/landing.html
+++ b/frontend/magic_links/templates/landing.html
@@ -72,8 +72,12 @@
         {% trans %}Get help{% endtrans %}
     </h2>
     <p>
+        {% if link_to_contact_us_page %}
+            If you have questions about the form or the fund, <a class="govuk-link" href="{{ contact_us_url }}">contact us.</a>
+        {% else %}
         {% trans %}If you have any questions about the form or the fund, email us at{% endtrans %} <a
             class="govuk-link" href="mailto:{{ contact_us_email_address }}">{{ contact_us_email_address }}</a>.
+        {% endif %}
     </p>
     <p>{% trans %}Do not send any applications or attachments by email. We'll only accept applications through this service.{% endtrans %}</p>
 

--- a/frontend/magic_links/templates/landing_eoi.html
+++ b/frontend/magic_links/templates/landing_eoi.html
@@ -73,8 +73,12 @@
         {% trans %}Get help{% endtrans %}
     </h2>
     <p>
-        {% trans %}If you have any questions about the form or the fund, {% endtrans %} <a
-            class="govuk-link" href="mailto:{{ contact_us_email_address }}">{% trans %}contact us{% endtrans %}</a>.
+        {% if link_to_contact_us_page %}
+            If you have questions about the form or the fund, <a class="govuk-link" href="{{ contact_us_url }}">contact us.</a>
+        {% else %}
+        {% trans %}If you have any questions about the form or the fund, email us at{% endtrans %} <a
+            class="govuk-link" href="mailto:{{ contact_us_email_address }}">{{ contact_us_email_address }}</a>.
+        {% endif %}
     </p>
     <p>{% trans %}Do not send any applications or attachments by email. We'll only accept applications through this service.{% endtrans %}</p>
   </div>

--- a/models/round.py
+++ b/models/round.py
@@ -22,6 +22,7 @@ class Round:
     support_times: str = ""
     application_guidance: str = ""
     is_expression_of_interest: bool = False
+    reference_contact_page_over_email: bool = False
 
     @classmethod
     def from_dict(cls, d: dict):

--- a/tests/test_magic_links.py
+++ b/tests/test_magic_links.py
@@ -241,6 +241,7 @@ class TestMagicLinks(AuthSessionView):
             mock_round.configure_mock(short_name="r2w3")
             mock_round.configure_mock(application_guidance="help text here")
             mock_round.configure_mock(contact_email="test@outlook.com")
+            mock_round.configure_mock(reference_contact_page_over_email=False)
             mock_round.configure_mock(is_expression_of_interest=False)
             mock_get_round_data.return_value = mock_round
 


### PR DESCRIPTION
### Change description

- Fund store has new property `reference_contact_page_over_email`
- We use this to determine whether we show a link to the contact us page, or their email

---

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines 
