### PR TITLE
bumping-up the versions

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -98,7 +98,7 @@ commonmark==0.9.1
     #   rich
 connexion==2.14.2
     # via -r requirements.txt
-cryptography==37.0.2
+cryptography==42.0.2
     # via
     #   -r requirements.txt
     #   msal
@@ -113,7 +113,7 @@ deepdiff==5.8.1
     # via -r requirements-dev.in
 distlib==0.3.4
     # via virtualenv
-dnspython==2.2.1
+dnspython==2.6.1
     # via
     #   -r requirements.txt
     #   email-validator
@@ -187,7 +187,7 @@ h11==0.13.0
     # via wsproto
 identify==2.5.1
     # via pre-commit
-idna==3.3
+idna==3.7
     # via
     #   -r requirements.txt
     #   email-validator
@@ -208,7 +208,7 @@ itsdangerous==2.1.2
     #   connexion
     #   flask
     #   flask-wtf
-jinja2==3.1.2
+jinja2==3.1.4
     # via
     #   -r requirements.txt
     #   flask
@@ -242,7 +242,7 @@ markupsafe==2.1.1
     #   wtforms
 mccabe==0.7.0
     # via flake8
-msal==1.18.0
+msal==1.28.0
     # via -r requirements.txt
 mypy-extensions==0.4.3
     # via black
@@ -382,7 +382,7 @@ redis==4.4.4
     #   -r requirements.txt
     #   flask-redis
     #   flipper-client
-requests==2.31.0
+requests==2.32.0
     # via
     #   -r requirements.txt
     #   connexion

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,13 +50,13 @@ commonmark==0.9.1
     # via rich
 connexion==2.14.2
     # via -r requirements.in
-cryptography==37.0.2
+cryptography==42.0.2
     # via
     #   msal
     #   pyjwt
 cssmin==0.2.0
     # via -r requirements.in
-dnspython==2.2.1
+dnspython==2.6.1
     # via email-validator
 email-validator==1.2.1
     # via -r requirements.in
@@ -104,7 +104,7 @@ govuk-frontend-jinja==2.3.0
     # via -r requirements.in
 gunicorn==20.1.0
     # via funding-service-design-utils
-idna==3.3
+idna==3.7
     # via
     #   email-validator
     #   requests
@@ -115,7 +115,7 @@ itsdangerous==2.1.2
     #   connexion
     #   flask
     #   flask-wtf
-jinja2==3.1.2
+jinja2==3.1.4
     # via
     #   flask
     #   flask-babel
@@ -141,7 +141,7 @@ markupsafe==2.1.1
     #   sentry-sdk
     #   werkzeug
     #   wtforms
-msal==1.18.0
+msal==1.28.0
     # via -r requirements.in
 openapi-schema-validator==0.2.3
     # via openapi-spec-validator
@@ -191,7 +191,7 @@ redis==4.4.4
     # via
     #   flask-redis
     #   flipper-client
-requests==2.31.0
+requests==2.32.0
     # via
     #   -r requirements.in
     #   connexion


### PR DESCRIPTION
bumping-up the versions

How to test
Updated the local dependencies and ran the pytest then got : 57 passed, 5046 warnings in 4.10s
Deployed the changes into local docker then tested the authentication

![image](https://github.com/communitiesuk/funding-service-design-authenticator/assets/15814084/a8cbf7a0-1d0e-4a50-882b-891a15f9ecee)
