### PR TITLE
bumping-up the versions

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -98,7 +98,7 @@ commonmark==0.9.1
     #   rich
 connexion==2.14.2
     # via -r requirements.txt
-cryptography==42.0.2
+cryptography==42.0.4
     # via
     #   -r requirements.txt
     #   msal
@@ -280,8 +280,6 @@ prance==0.21.8.0
     # via -r requirements.txt
 pre-commit==2.19.0
     # via -r requirements-dev.in
-py==1.11.0
-    # via pytest
 pycodestyle==2.11.1
     # via flake8
 pycparser==2.21
@@ -501,7 +499,7 @@ werkzeug==2.2.3
     #   connexion
     #   flask
     #   pytest-flask
-wheel==0.37.1
+wheel==0.38.1
     # via pip-tools
 wsproto==1.1.0
     # via trio-websocket

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ commonmark==0.9.1
     # via rich
 connexion==2.14.2
     # via -r requirements.in
-cryptography==42.0.2
+cryptography==42.0.4
     # via
     #   msal
     #   pyjwt


### PR DESCRIPTION
bumping-up the versions

How to test
Updated the local dependencies and ran the pytest then got : 57 passed, 5046 warnings in 3.51s
Deployed the changes into local docker then tested the authentication

![image](https://github.com/communitiesuk/funding-service-design-authenticator/assets/15814084/76baa76c-979b-4168-83d7-3b3b31be7a98)
