### PR TITLE
BAU: Default AWS region

### DIFF
--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -260,7 +260,7 @@ class DefaultConfig(object):
     # ---------------
     AWS_ACCESS_KEY_ID = AWS_SQS_ACCESS_KEY_ID = environ.get("AWS_ACCESS_KEY_ID")
     AWS_SECRET_ACCESS_KEY = AWS_SQS_SECRET_ACCESS_KEY = environ.get("AWS_SECRET_ACCESS_KEY")
-    AWS_REGION = AWS_SQS_REGION = environ.get("AWS_REGION")
+    AWS_REGION = AWS_SQS_REGION = environ.get("AWS_REGION", "eu-west-2")
     AWS_ENDPOINT_OVERRIDE = environ.get("AWS_ENDPOINT_OVERRIDE")
 
     # ---------------


### PR DESCRIPTION
### Change description
Default AWS region, without this authenticator fails to start-up with
`botocore.exceptions.NoRegionError: You must specify a region.`


- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Error `botocore.exceptions.NoRegionError: You must specify a region.` no longer fails at start-up


### Screenshots of UI changes (if applicable)
