### PR TITLE
FPASF-376: add return_path argument for sign-out/sign-in 

### DIFF
--- a/api/session/auth_session.py
+++ b/api/session/auth_session.py
@@ -56,6 +56,7 @@ class AuthSessionView(MethodView):
 
         Returns: 302 redirect to signed-out page
         """
+        return_path = request.args.get("return_path")
         fund_short_name = None
         round_short_name = None
         existing_auth_token = request.cookies.get(Config.FSD_USER_TOKEN_COOKIE_NAME)
@@ -104,6 +105,7 @@ class AuthSessionView(MethodView):
             fund=fund_short_name,
             round=round_short_name,
             return_app=return_app,
+            return_path=return_path,
         )
         response = make_response(redirect(signed_out_url), 302)
         response.set_cookie(

--- a/api/sso/routes.py
+++ b/api/sso/routes.py
@@ -27,6 +27,7 @@ class SsoView(MethodView):
 
         if return_app := request.args.get("return_app"):
             session["return_app"] = return_app
+            session["return_path"] = request.args.get("return_path")
             current_app.logger.debug(f"Setting return app to {return_app} for this session")
 
         return redirect(session["flow"]["auth_uri"]), 302
@@ -96,7 +97,11 @@ class SsoView(MethodView):
         redirect_url = Config.ASSESSMENT_POST_LOGIN_URL  # TODO: Remove defaulting to Assessment, instead use return_app
         if return_app := session.get("return_app"):
             if safe_app := Config.SAFE_RETURN_APPS.get(return_app):
-                redirect_url = safe_app.login_url
+                if return_path := session.get("return_path"):
+                    redirect_url = safe_app.login_url + return_path
+                else:
+                    redirect_url = safe_app.login_url
+
                 current_app.logger.info(f"Returning to {return_app} @ {redirect_url}")
             else:
                 current_app.logger.warning(f"{return_app} not listed as a safe app.")

--- a/api/sso/routes.py
+++ b/api/sso/routes.py
@@ -1,5 +1,6 @@
 import warnings
 from urllib.parse import urlencode
+from urllib.parse import urlparse
 
 import msal
 import requests
@@ -98,7 +99,7 @@ class SsoView(MethodView):
         if return_app := session.get("return_app"):
             if safe_app := Config.SAFE_RETURN_APPS.get(return_app):
                 if return_path := session.get("return_path"):
-                    redirect_url = safe_app.login_url + return_path
+                    redirect_url = self._get_hostname_from_url(safe_app.login_url) + return_path
                 else:
                     redirect_url = safe_app.login_url
 
@@ -151,6 +152,11 @@ class SsoView(MethodView):
             client_credential=Config.AZURE_AD_CLIENT_SECRET,
             token_cache=cache,
         )
+
+    @staticmethod
+    def _get_hostname_from_url(url):
+        parsed_uri = urlparse(url)
+        return f"{parsed_uri.scheme}://{parsed_uri.netloc}"
 
     def build_auth_code_flow(self, authority=None, scopes=None):
         return self._build_msal_app(authority=authority).initiate_auth_code_flow(

--- a/api/sso/routes.py
+++ b/api/sso/routes.py
@@ -99,7 +99,7 @@ class SsoView(MethodView):
         if return_app := session.get("return_app"):
             if safe_app := Config.SAFE_RETURN_APPS.get(return_app):
                 if return_path := session.get("return_path"):
-                    redirect_url = self._get_hostname_from_url(safe_app.login_url) + return_path
+                    redirect_url = self._get_origin_from_url(safe_app.login_url) + return_path
                 else:
                     redirect_url = safe_app.login_url
 
@@ -154,7 +154,7 @@ class SsoView(MethodView):
         )
 
     @staticmethod
-    def _get_hostname_from_url(url):
+    def _get_origin_from_url(url):
         parsed_uri = urlparse(url)
         return f"{parsed_uri.scheme}://{parsed_uri.netloc}"
 

--- a/config/envs/unit_test.py
+++ b/config/envs/unit_test.py
@@ -86,7 +86,7 @@ class UnitTestConfig(Config):
 
     SAFE_RETURN_APPS = {
         SupportedApp.POST_AWARD_FRONTEND.value: SafeAppConfig(
-            login_url=POST_AWARD_FRONTEND_HOST + "/",
+            login_url=POST_AWARD_FRONTEND_HOST + "/login",
             logout_endpoint="sso_bp.signed_out",
             service_title="Find monitoring and evaluation data",
         ),

--- a/config/envs/unit_test.py
+++ b/config/envs/unit_test.py
@@ -4,8 +4,10 @@ from os import getenv
 
 import redis
 from config.envs.default import DefaultConfig as Config
+from config.envs.default import SafeAppConfig
 from distutils.util import strtobool
 from fsd_utils import configclass
+from fsd_utils.authentication.config import SupportedApp
 
 
 @configclass
@@ -79,3 +81,18 @@ class UnitTestConfig(Config):
     # S3 Config
     # ---------------
     AWS_MSG_BUCKET_NAME = "fsd-notification-bucket"
+
+    POST_AWARD_FRONTEND_HOST = "http://post-award-frontend"
+
+    SAFE_RETURN_APPS = {
+        SupportedApp.POST_AWARD_FRONTEND.value: SafeAppConfig(
+            login_url=POST_AWARD_FRONTEND_HOST + "/",
+            logout_endpoint="sso_bp.signed_out",
+            service_title="Find monitoring and evaluation data",
+        ),
+        SupportedApp.POST_AWARD_SUBMIT.value: SafeAppConfig(
+            login_url="http://submit/",
+            logout_endpoint="sso_bp.signed_out",
+            service_title="Submit monitoring and evaluation data",
+        ),
+    }

--- a/frontend/sso/routes.py
+++ b/frontend/sso/routes.py
@@ -15,11 +15,12 @@ sso_bp = Blueprint(
 @sso_bp.route("/signed-out/<status>")
 def signed_out(status):
     return_app = request.args.get("return_app")
+    return_path = request.args.get("return_path")
     return (
         render_template(
             "sso_signed_out.html",
             status=status,
-            login_url=url_for(Config.SSO_LOGIN_ENDPOINT, return_app=return_app),
+            login_url=url_for(Config.SSO_LOGIN_ENDPOINT, return_app=return_app, return_path=return_path),
         ),
         200,
     )

--- a/tests/test_signout.py
+++ b/tests/test_signout.py
@@ -263,3 +263,10 @@ class TestSignout:
         page_html = BeautifulSoup(response.data)
         assert response.status_code == 200
         assert "Access Funding" in str(page_html)
+
+    def test_signout_retains_return_path(self, flask_test_client, mock_redis_sessions):
+        endpoint = "/sessions/sign-out?return_app=post-award-frontend&return_path=/foo"
+        response = flask_test_client.get(endpoint)
+
+        assert response.status_code == 302
+        assert response.location == "/service/sso/signed-out/no_token?return_app=post-award-frontend&return_path=%2Ffoo"

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -209,7 +209,29 @@ def test_sso_get_token_redirects_to_return_app_login_url(
 
     response = flask_test_client.get(endpoint)
 
-    assert response.location == "/"  # post-award-frontend host location set to empty string in default config
+    assert response.location == "http://post-award-frontend/"
+
+
+def test_sso_get_token_redirects_to_return_app_login_url_with_request_path(
+    flask_test_client, mock_msal_client_application, mock_redis_sessions
+):
+    """
+    GIVEN We have a functioning Authenticator API
+    WHEN a GET request for /sso/get-token with a valid
+        response from azure_ad via the mock_msal_client_application
+        with a VALID return app set in the session
+    THEN we should receive a 302 redirect response with
+        the correct location to the return_app
+    """
+    endpoint = "/sso/get-token"
+
+    with flask_test_client.session_transaction() as test_session:
+        test_session["return_app"] = "post-award-frontend"
+        test_session["return_path"] = "/foo"
+
+    response = flask_test_client.get(endpoint)
+
+    assert response.location == "http://post-award-frontend//foo"
 
 
 def test_sso_get_token_400_abort_with_invalid_return_app(

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -34,6 +34,14 @@ def test_sso_login_sets_return_app_in_session(flask_test_client):
     assert session.get("return_app") == return_app
 
 
+def test_sso_login_sets_return_path_in_session(flask_test_client):
+    return_app = "post-award-frontend"
+
+    endpoint = f"/sso/login?return_app={return_app}&return_path=/foo"
+    flask_test_client.get(endpoint)
+    assert session.get("return_path") == "/foo"
+
+
 def test_sso_logout_redirects_to_ms(flask_test_client):
     """
     GIVEN We have a functioning Authenticator API

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -209,10 +209,10 @@ def test_sso_get_token_redirects_to_return_app_login_url(
 
     response = flask_test_client.get(endpoint)
 
-    assert response.location == "http://post-award-frontend/"
+    assert response.location == "http://post-award-frontend/login"
 
 
-def test_sso_get_token_redirects_to_return_app_login_url_with_request_path(
+def test_sso_get_token_redirects_to_return_app_host_with_request_path(
     flask_test_client, mock_msal_client_application, mock_redis_sessions
 ):
     """
@@ -231,7 +231,7 @@ def test_sso_get_token_redirects_to_return_app_login_url_with_request_path(
 
     response = flask_test_client.get(endpoint)
 
-    assert response.location == "http://post-award-frontend//foo"
+    assert response.location == "http://post-award-frontend/foo"
 
 
 def test_sso_get_token_400_abort_with_invalid_return_app(


### PR DESCRIPTION
### Change description
Adds ability to set a `return_path` where a `return_app` is specified.
This is useful in order to customise the redirect for signed out users where we want them to return to a specific route post sign-in rather than being returned to the homepage

Note in order to work end-to-end with services this will require a change in the utils library which will be introduced in a subsequent PR

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
(when running post-award docker runner)
Go to: `http://localhost:4004/service/sso/signed-out/no_token?return_app=post-award-frontend&return_path=/data-glossary`
Click login
Follow Microsoft sign-in flow
#### Expected result
Should be redirected to data-glossary on data-frontend




### Screenshots of UI changes (if applicable)
