### PR TITLE
FS-4547 removing magic links create endpoint

### DIFF
--- a/api/magic_links/routes.py
+++ b/api/magic_links/routes.py
@@ -2,8 +2,6 @@ import json
 import urllib.parse
 from datetime import datetime
 
-from api.responses import error_response
-from api.responses import magic_link_201_response
 from api.session.auth_session import AuthSessionView
 from config import Config
 from flask import current_app
@@ -14,7 +12,6 @@ from flask import url_for
 from flask.views import MethodView
 from fsd_utils.authentication.decorators import login_requested
 from models.account import AccountMethods
-from models.magic_link import MagicLinkError
 from models.magic_link import MagicLinkMethods
 
 
@@ -107,23 +104,3 @@ class MagicLinksView(MagicLinkMethods, MethodView):
                 round=round_short_name,
             )
         )
-
-    def create(self):
-        """
-        Creates a magic link for an existing account holder
-        :param email: the account holders email address
-        :param redirect_url: the url the link should redirect to
-        :return: a json of the magic link created (or an error of failure)
-        """
-        email = request.get_json().get("email")
-        redirect_url = request.get_json().get("redirectUrl")
-        if not email:
-            return error_response(400, "Email is required")
-        account = AccountMethods.get_account(email)
-        if account:
-            try:
-                new_link_json = self.create_magic_link(account, redirect_url)
-                return magic_link_201_response(new_link_json)
-            except MagicLinkError:
-                return error_response(500, "Could not create a unique link")
-        return error_response(401, "Account does not exist")

--- a/app.py
+++ b/app.py
@@ -44,9 +44,7 @@ def create_app() -> Flask:
     init_sentry()
 
     # Initialise Connexion Flask App
-    connexion_options = {
-        "swagger_url": "/docs",
-    }
+    connexion_options = Config.CONNEXION_OPTIONS
     connexion_app = connexion.FlaskApp(
         "Authenticator",
         specification_dir="/openapi/",

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -279,3 +279,6 @@ class DefaultConfig(object):
     REDIS_MLINKS_URL = REDIS_INSTANCE_URI + "/0"
     REDIS_SESSIONS_URL = REDIS_INSTANCE_URI + "/1"
     SESSION_REDIS = redis.from_url(REDIS_SESSIONS_URL)
+
+    # Connexion
+    CONNEXION_OPTIONS = {}

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -71,3 +71,8 @@ class DevelopmentConfig(Config):
 
     # Security
     Config.TALISMAN_SETTINGS["force_https"] = False
+
+    # Connexion
+    CONNEXION_OPTIONS = {
+        "swagger_url": "/docs",
+    }

--- a/models/account.py
+++ b/models/account.py
@@ -183,7 +183,7 @@ class AccountMethods(Account):
         email: str,
         fund_short_name: str = None,
         round_short_name: str = None,
-    ) -> bool:
+    ) -> str:
         """
         Create a new magic link for a user
         and send it in a notification
@@ -191,7 +191,7 @@ class AccountMethods(Account):
         :param email: The user's account email address
         :param fund_id: The fund id
         :param round_id: The round id
-        :return: True if successfully created
+        :return: The authenticator url to use the magic link (landing page)
         """
         account = cls.get_account(email)
         if not account:

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -27,35 +27,6 @@ paths:
                 type: array
                 items:
                   type: string
-    post:
-      tags:
-        - magic links
-      summary: Create a magic link
-      description: Get a fresh magic link for an account holder
-      operationId: api.MagicLinksView.create
-      requestBody:
-        description: Magic link creation parameters
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: 'components.yml#/components/schemas/MagicLinkCreate'
-            example:
-              email: 'a@example.com'
-              redirectUrl: 'https://example.com/redirect-url'
-      responses:
-        201:
-          description: SUCCESS - Active magic link created
-          content:
-            application/json:
-              schema:
-                $ref: 'components.yml#/components/schemas/MagicLink'
-        401:
-          description: ERROR - Could not create magic link
-          content:
-            application/json:
-              schema:
-                $ref: 'components.yml#/components/schemas/GeneralError'
 
   '/magic-links/{link_id}':
     get:

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -15,3 +15,4 @@ pip-tools>=6.13.0
 selenium==4.2.0
 webdriver-manager==4.0.1
 Flake8-pyproject
+swagger-ui-bundle

--- a/requirements.in
+++ b/requirements.in
@@ -44,7 +44,6 @@ msal==1.18.0
 #   Connexion APIs
 #-----------------------------------
 connexion==2.14.2
-swagger-ui-bundle
 openapi-spec-validator
 prance
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -228,8 +228,6 @@ sqlalchemy==2.0.28
     #   sqlalchemy-utils
 sqlalchemy-utils==0.41.1
     # via funding-service-design-utils
-swagger-ui-bundle==0.0.9
-    # via -r requirements.in
 thrift==0.16.0
     # via flipper-client
 typing-extensions==4.10.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 from app import create_app
 from flask import current_app
+from models.account import AccountMethods
 from testing.mocks.mocks import *  # noqa
 
 
@@ -9,3 +10,22 @@ def app_context():
     with create_app().app_context():
         with current_app.test_request_context():
             yield
+
+
+@pytest.fixture(scope="function")
+def create_magic_link(mocker):
+    from models.fund import Fund
+    from models.round import Round
+
+    mocker.patch(
+        "models.account.FundMethods.get_fund",
+        return_value=Fund(
+            name="test fund", fund_title="hello", short_name="COF", identifier="asdfasdf", description="asdfasdfasdf"
+        ),
+    )
+    mocker.patch("models.account.get_round_data", return_value=Round(contact_email="asdf@asdf.com"))
+    mocker.patch("models.account.Notification.send", return_value=True)
+    auth_landing = AccountMethods.get_magic_link("a@example.com", "cof", "r1w1")
+    link_key_end = auth_landing.index("?fund=")
+    link_key = auth_landing[link_key_end - 8 : link_key_end]  # noqa:E203
+    yield link_key

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -96,7 +96,7 @@ class TestAccountMethods(object):
         )
         assert result.email == "john@example.com"
 
-    def test_create_magic_link(self, mocker, mock_get_account, flask_test_client):
+    def test_create_magic_link(self, mocker, mock_get_account, flask_test_client, mock_redis_magic_links):
         mocker.patch(
             "models.account.FundMethods.get_fund",
             return_value=Fund(

--- a/tests/test_healthchecks.py
+++ b/tests/test_healthchecks.py
@@ -1,4 +1,8 @@
+from unittest import mock
+
 import pytest
+from app import create_app
+from config import Config
 
 
 @pytest.mark.app(debug=False)
@@ -16,3 +20,19 @@ class TestHealthchecks:
         }
         assert response.status_code == 200, "Unexpected response code"
         assert response.json == expected_dict, "Unexpected json body"
+
+    @mock.patch.object(Config, "CONNEXION_OPTIONS", {})
+    def test_swagger_ui_not_published(self):
+        with create_app().app_context() as app_context:
+            with app_context.app.test_client() as test_client:
+                use_endpoint = "/docs"
+                response = test_client.get(use_endpoint, follow_redirects=True)
+                assert response.status_code == 404
+
+    @mock.patch.object(Config, "CONNEXION_OPTIONS", {"swagger_url": "/docs"})
+    def test_swagger_ui_is_published(self):
+        with create_app().app_context() as app_context:
+            with app_context.app.test_client() as test_client:
+                use_endpoint = "/docs"
+                response = test_client.get(use_endpoint, follow_redirects=True)
+                assert response.status_code == 200

--- a/tests/test_magic_links.py
+++ b/tests/test_magic_links.py
@@ -19,30 +19,6 @@ from security.utils import validate_token
 @pytest.mark.usefixtures("flask_test_client")
 @pytest.mark.usefixtures("mock_redis_magic_links")
 class TestMagicLinks(AuthSessionView):
-    created_link_keys = []
-    used_link_keys = []
-
-    def test_magic_link_is_created(self, flask_test_client):
-        """
-        GIVEN a running Flask client, redis instance and
-        an existing h@a.com account in the account_store api
-        WHEN we POST to /magic-links/a@example.com
-        THEN a magic link is created and returned
-        :param flask_test_client:
-        """
-        expected_link_attributes = {"accountId": "usera"}
-        payload = {
-            "email": "a@example.com",
-            "redirectUrl": "https://example.com/redirect-url",
-        }
-        endpoint = "/magic-links"
-        response = flask_test_client.post(endpoint, json=payload)
-        magic_link = response.get_json()
-        self.created_link_keys.append(magic_link.get("key"))
-
-        assert response.status_code == 201
-        assert magic_link.get("accountId") == expected_link_attributes.get("accountId")
-
     def test_new_magic_link_does_not_create_application(self, flask_test_client, mocker, mock_create_application):
         """
         GIVEN a running Flask client, redis instance and
@@ -93,7 +69,7 @@ class TestMagicLinks(AuthSessionView):
             mock_get_round_data_frontend.assert_called()
             assert response.status_code == 302, response.data
 
-    def test_magic_link_redirects_to_landing(self, flask_test_client):
+    def test_magic_link_redirects_to_landing(self, flask_test_client, create_magic_link):
         """
         GIVEN a running Flask client, redis instance and
         an existing magic link
@@ -102,15 +78,13 @@ class TestMagicLinks(AuthSessionView):
         (without using the single use magic token)
         :param flask_test_client:
         """
-        link_key = self.created_link_keys.pop(0)
-        self.created_link_keys.append(link_key)
+        link_key = create_magic_link
         use_endpoint = f"/magic-links/landing/{link_key}"
         response = flask_test_client.get(use_endpoint)
-        self.used_link_keys.append(link_key)
 
         assert response.status_code == 302
 
-    def test_magic_link_sets_auth_cookie(self, flask_test_client):
+    def test_magic_link_sets_auth_cookie(self, flask_test_client, create_magic_link):
         """
         GIVEN a running Flask client, redis instance and
         an existing magic link
@@ -118,15 +92,13 @@ class TestMagicLinks(AuthSessionView):
         THEN we are redirected to another url (the application service)
         :param flask_test_client:
         """
-        link_key = self.created_link_keys.pop(0)
-        self.created_link_keys.append(link_key)
+        link_key = create_magic_link
         use_endpoint = f"/magic-links/{link_key}"
         response = flask_test_client.get(use_endpoint)
-        self.used_link_keys.append(link_key)
 
         assert "fsd_user_token" in response.headers.get("Set-Cookie")
 
-    def test_magic_link_sets_valid_cookie_token(self, flask_test_client):
+    def test_magic_link_sets_valid_cookie_token(self, flask_test_client, create_magic_link):
         """
         GIVEN a running Flask client, redis instance and
         and a valid magic link
@@ -136,18 +108,9 @@ class TestMagicLinks(AuthSessionView):
         """
         expected_account_id = "usera"
         expected_cookie_name = "fsd_user_token"
-        magic_link_create_payload = {
-            "email": "a@example.com",
-            "redirectUrl": "https://example.com/redirect-url",
-        }
-        endpoint = "/magic-links"
-        response = flask_test_client.post(endpoint, json=magic_link_create_payload)
-        magic_link = response.get_json()
-        link_key = magic_link.get("key")
-        self.created_link_keys.append(link_key)
+        link_key = create_magic_link
         use_endpoint = f"/magic-links/{link_key}"
         flask_test_client.get(use_endpoint)
-        self.used_link_keys.append(link_key)
         auth_cookie = next(
             (cookie for cookie in flask_test_client.cookie_jar if cookie.name == expected_cookie_name),
             None,
@@ -161,7 +124,7 @@ class TestMagicLinks(AuthSessionView):
         credentials = validate_token(self.valid_token)
         assert credentials.get("accountId") == expected_account_id
 
-    def test_magic_link_redirects(self, flask_test_client):
+    def test_magic_link_redirects(self, flask_test_client, create_magic_link):
         """
         GIVEN a running Flask client, redis instance and
         an existing magic link
@@ -169,14 +132,12 @@ class TestMagicLinks(AuthSessionView):
         THEN we are redirected to another url (the application service)
         :param flask_test_client:
         """
-        link_key = self.created_link_keys.pop(0)
-        use_endpoint = f"/magic-links/{link_key}"
+        use_endpoint = f"/magic-links/{create_magic_link}"
         response = flask_test_client.get(use_endpoint)
-        self.used_link_keys.append(link_key)
 
         assert response.status_code == 302
 
-    def test_reused_magic_link_redirects_for_active_session(self, flask_test_client):
+    def test_reused_magic_link_redirects_for_active_session(self, flask_test_client, create_magic_link):
         """
         GIVEN a running Flask client, redis instance and
         a used magic link with an active session (cookie)
@@ -185,28 +146,19 @@ class TestMagicLinks(AuthSessionView):
         :param flask_test_client:
         """
 
-        magic_link_create_payload = {
-            "email": "a@example.com",
-            "redirectUrl": "https://example.com/redirect-url",
-        }
-        endpoint = "/magic-links"
-        response = flask_test_client.post(endpoint, json=magic_link_create_payload)
-        magic_link = response.get_json()
-        link_key = magic_link.get("key")
-        self.created_link_keys.append(link_key)
+        link_key = create_magic_link
         use_endpoint = f"/magic-links/{link_key}"
         reuse_endpoint = f"/magic-links/{link_key}"
 
         # first use of magic link
         first_response = flask_test_client.get(use_endpoint)
         assert first_response.status_code == 302
-        self.used_link_keys.append(link_key)
 
         # second use of used magic link but now authorised (cookie present)
         second_response = flask_test_client.get(reuse_endpoint)
         assert second_response.status_code == 302
 
-    def test_reused_magic_link_with_active_session_shows_landing(self, flask_test_client):
+    def test_reused_magic_link_with_active_session_shows_landing(self, flask_test_client, create_magic_link):
         """
         GIVEN a running Flask client, redis instance and
         a used magic link with an active session (cookie)
@@ -215,16 +167,7 @@ class TestMagicLinks(AuthSessionView):
         :param flask_test_client:
         """
 
-        magic_link_create_payload = {
-            "email": "a@example.com",
-            "redirectUrl": "https://example.com/redirect-url",
-        }
-        endpoint = "/magic-links"
-        response = flask_test_client.post(endpoint, json=magic_link_create_payload)
-        magic_link = response.get_json()
-
-        link_key = magic_link.get("key")
-        self.created_link_keys.append(link_key)
+        link_key = create_magic_link
         use_endpoint = f"/magic-links/{link_key}"
         landing_endpoint = f"/service/magic-links/landing/{link_key}?fund=cof&round=r2w3"
 
@@ -277,7 +220,6 @@ class TestMagicLinks(AuthSessionView):
             # use link
             use_link_response = flask_test_client.get(use_endpoint)
             assert use_link_response.status_code == 302
-            self.used_link_keys.append(link_key)
 
             # re-use magic link landing but now authorised (cookie present)
             second_landing_response = flask_test_client.get(landing_endpoint)
@@ -285,7 +227,7 @@ class TestMagicLinks(AuthSessionView):
             soup = BeautifulSoup(second_landing_response.data, "html.parser")
             assert soup.find("a", class_="govuk-button govuk-button--start").text.strip() == "Continue"
 
-    def test_reused_magic_link_with_no_session_returns_link_expired(self, flask_test_client):
+    def test_reused_magic_link_with_no_session_returns_link_expired(self, flask_test_client, create_magic_link):
         """
         GIVEN a running Flask client, redis instance and
         a used magic link with no session
@@ -293,10 +235,22 @@ class TestMagicLinks(AuthSessionView):
         THEN we receive a 403 Forbidden response
         :param flask_test_client:
         """
-        used_link_key = self.used_link_keys.pop(0)
-        reuse_endpoint = f"/magic-links/{used_link_key}"
-        response = flask_test_client.get(reuse_endpoint, follow_redirects=True)
 
+        link_key = create_magic_link
+        use_endpoint = f"/magic-links/{link_key}"
+        reuse_endpoint = f"/magic-links/{link_key}"
+
+        # first use of magic link
+        first_response = flask_test_client.get(use_endpoint)
+        assert first_response.status_code == 302
+
+        # sign out
+        endpoint = "/sessions/sign-out"
+        response = flask_test_client.get(endpoint)
+        assert response.status_code == 302
+
+        # try and reuse same link
+        response = flask_test_client.get(reuse_endpoint, follow_redirects=True)
         assert response.status_code == 403
         assert b"Link expired" in response.data
         assert b"Request a new link" in response.data

--- a/tests/test_signout.py
+++ b/tests/test_signout.py
@@ -60,7 +60,7 @@ class TestSignout:
                 == "/service/magic-links/signed-out/sign_out_request?fund=test_fund&round=test_round"  # noqa
             )
 
-    def test_magic_link_auth_can_be_signed_out(self, flask_test_client, mock_redis_sessions):
+    def test_magic_link_auth_can_be_signed_out(self, mocker, flask_test_client, mock_redis_sessions, create_magic_link):
         """
         GIVEN a running Flask client, redis instance and
         and a valid magic link has been clicked and a valid
@@ -71,17 +71,9 @@ class TestSignout:
         """
         expected_account_id = "usera"
         expected_cookie_name = "fsd_user_token"
-        magic_link_create_payload = {
-            "email": "a@example.com",
-            "redirectUrl": "https://example.com/redirect-url",
-        }
-        endpoint = "/magic-links"
-        response = flask_test_client.post(endpoint, json=magic_link_create_payload)
-        magic_link = response.get_json()
-        link_key = magic_link.get("key")
+        link_key = create_magic_link
         self.created_link_keys.append(link_key)
         use_endpoint = f"/magic-links/{link_key}"
-        flask_test_client.get(use_endpoint)
         flask_test_client.get(use_endpoint)
         self.used_link_keys.append(link_key)
         auth_cookie = next(


### PR DESCRIPTION
### Change description

- Removes the 'Create magic link' endpoint
- Creates a unit test fixture to create a magic link for testing of auth
- Updates tests to use that new fixture
- `swagger-ui` now installed only as a dev dependency and the ui is only publish when running locally.

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Login and authenticate with a magic link as usual.

