### PR TITLE
Prevent SYSTEM_ROLES to be removed when login

### DIFF
--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -1,17 +1,15 @@
 """Flask configuration."""
+
 import base64
 import logging
 from collections import namedtuple
-from os import environ
-from os import getenv
+from distutils.util import strtobool
+from os import environ, getenv
 from pathlib import Path
 
 import redis
-from distutils.util import strtobool
-from fsd_utils import CommonConfig
-from fsd_utils import configclass
+from fsd_utils import CommonConfig, configclass
 from fsd_utils.authentication.config import SupportedApp
-
 
 SafeAppConfig = namedtuple("SafeAppConfig", ("login_url", "logout_endpoint", "service_title"))
 
@@ -58,8 +56,7 @@ class DefaultConfig(object):
     AZURE_AD_TENANT_ID = environ.get("AZURE_AD_TENANT_ID", "")
     AZURE_AD_AUTHORITY = (
         # consumers|organizations|<tenant_id> - signifies the Azure AD tenant endpoint # noqa
-        "https://login.microsoftonline.com/"
-        + AZURE_AD_TENANT_ID
+        "https://login.microsoftonline.com/" + AZURE_AD_TENANT_ID
     )
     AZURE_AD_REDIRECT_PATH = (
         # Used for forming an absolute URL to your redirect URI.

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -1,14 +1,15 @@
 """Flask configuration."""
-
 import base64
 import logging
 from collections import namedtuple
-from distutils.util import strtobool
-from os import environ, getenv
+from os import environ
+from os import getenv
 from pathlib import Path
 
 import redis
-from fsd_utils import CommonConfig, configclass
+from distutils.util import strtobool
+from fsd_utils import CommonConfig
+from fsd_utils import configclass
 from fsd_utils.authentication.config import SupportedApp
 
 SafeAppConfig = namedtuple("SafeAppConfig", ("login_url", "logout_endpoint", "service_title"))
@@ -56,7 +57,8 @@ class DefaultConfig(object):
     AZURE_AD_TENANT_ID = environ.get("AZURE_AD_TENANT_ID", "")
     AZURE_AD_AUTHORITY = (
         # consumers|organizations|<tenant_id> - signifies the Azure AD tenant endpoint # noqa
-        "https://login.microsoftonline.com/" + AZURE_AD_TENANT_ID
+        "https://login.microsoftonline.com/"
+        + AZURE_AD_TENANT_ID
     )
     AZURE_AD_REDIRECT_PATH = (
         # Used for forming an absolute URL to your redirect URI.

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -73,6 +73,9 @@ class DefaultConfig(object):
     # https://docs.microsoft.com/en-us/graph/permissions-reference
     MS_GRAPH_PERMISSIONS_SCOPE = ["User.ReadBasic.All"]
 
+    # Custom roles
+    SYSTEM_ROLES = ["OFFICER_151"]
+
     """
     Session
     """

--- a/models/account.py
+++ b/models/account.py
@@ -166,6 +166,12 @@ class AccountMethods(Account):
                 )
             )
 
+        # Update AD roles with current system roles user currently has
+        current_roles = account.roles or []
+        for system_role in Config.SYSTEM_ROLES:
+            if system_role in current_roles:
+                roles.append(system_role)
+
         # Update account with the latest roles, email and name
         account = AccountMethods.update_account(
             id=account.id,

--- a/models/account.py
+++ b/models/account.py
@@ -1,12 +1,15 @@
 from dataclasses import dataclass
 from typing import List
 
-from flask import current_app
-from fsd_utils.config.notify_constants import NotifyConstants
-
 import config
 from config import Config
-from models.data import get_account_data, get_data, get_round_data, post_data, put_data
+from flask import current_app
+from fsd_utils.config.notify_constants import NotifyConstants
+from models.data import get_account_data
+from models.data import get_data
+from models.data import get_round_data
+from models.data import post_data
+from models.data import put_data
 from models.fund import FundMethods
 from models.magic_link import MagicLinkMethods
 from models.notification import Notification

--- a/models/account.py
+++ b/models/account.py
@@ -1,15 +1,12 @@
 from dataclasses import dataclass
 from typing import List
 
-import config
-from config import Config
 from flask import current_app
 from fsd_utils.config.notify_constants import NotifyConstants
-from models.data import get_account_data
-from models.data import get_data
-from models.data import get_round_data
-from models.data import post_data
-from models.data import put_data
+
+import config
+from config import Config
+from models.data import get_account_data, get_data, get_round_data, post_data, put_data
 from models.fund import FundMethods
 from models.magic_link import MagicLinkMethods
 from models.notification import Notification

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,6 +1,6 @@
 import pytest
-from models.account import Account
-from models.account import AccountMethods
+
+from models.account import Account, AccountMethods
 from models.fund import Fund
 from models.round import Round
 
@@ -35,7 +35,6 @@ def mock_get_account(mocker, request):
 
 @pytest.fixture(scope="function")
 def mock_create_account(mocker):
-
     mocker.patch(
         "models.account.post_data",
         return_value={

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,6 +1,6 @@
 import pytest
-
-from models.account import Account, AccountMethods
+from models.account import Account
+from models.account import AccountMethods
 from models.fund import Fund
 from models.round import Round
 


### PR DESCRIPTION
Created from https://github.com/communitiesuk/funding-service-design-authenticator/pull/326

### Change description
Prevent SYSTEM_ROLES to be removed when login.

At the moment when we login we refresh the account role in the database
with the roles we get from AD.

This prevents that. We check the system roles the user had, and adds
them back to the array of roles before we trigger the update.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")