### PR TITLE
Turn warnings into errors when running pytest

### DIFF
--- a/api/magic_links/routes.py
+++ b/api/magic_links/routes.py
@@ -89,7 +89,7 @@ class MagicLinksView(MagicLinkMethods, MethodView):
             query_params = {k: v for k, v in query_params.items() if v is not None}
             query_string = urllib.parse.urlencode(query_params)
             frontend_account_url = f"{Config.MAGIC_LINK_REDIRECT_URL}?{query_string}"
-            current_app.logger.warn(
+            current_app.logger.warning(
                 f"The magic link with hash: '{link_hash}' has already been"
                 f" used but the user with account_id: '{g.account_id}' is"
                 " logged in, redirecting to"

--- a/api/session/auth_session.py
+++ b/api/session/auth_session.py
@@ -77,7 +77,7 @@ class AuthSessionView(MethodView):
                 valid_token = decode_with_options(existing_auth_token, options={"verify_exp": False})
                 status = "expired_token"
             except jwt.PyJWTError as e:
-                current_app.logger.warn(f"PyJWTError: {e.__class__.__name__} - {e}")
+                current_app.logger.warning(f"PyJWTError: {e.__class__.__name__} - {e}")
                 status = "invalid_token"
 
             # If validly issued token: create query params for signout url,

--- a/frontend/magic_links/routes.py
+++ b/frontend/magic_links/routes.py
@@ -69,7 +69,7 @@ def landing(link_id):
     round_data = get_round_data(fund_short_name, round_short_name)
 
     if not bool(fund_data and round_data):
-        current_app.logger.warn("Fund and round information missing from query string")
+        current_app.logger.warning("Fund and round information missing from query string")
         return abort(404)
 
     fund_short_name = fund_data.short_name

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,20 +3,21 @@ env =
     FLASK_ENV=unit_test
     GITHUB_SHA=abc123
     AWS_REGION=eu-west-2
+markers =
+  new_account: toggle whether get_account should be mocked to return an existing account or not
 
-;ReportPortal `pytest-reportportal` plugin
-;ReportPortal (required)
-rp_endpoint = http://localhost:8080
-rp_uuid = [UUID from USER PROFILE section of ReportPortal]
-rp_launch = EXAMPLE_TEST_RUN_NAME
-rp_project = default_personal
-
-;For more info, including other pytest.ini options, visit: https://github.com/reportportal/agent-python-pytest
-;ReportPortal (optional)
-rp_ignore_errors = True
-rp_hierarchy_dirs = True
-rp_hierarchy_module = False
-rp_hierarchy_class = False
 
 filterwarnings =
   error
+  ignore:'_request_ctx_stack' is deprecated and will be removed in Flask 2.3.:DeprecationWarning:flask_assets
+  ignore:'_app_ctx_stack' is deprecated and will be removed in Flask 2.3.:DeprecationWarning:flask_assets
+
+  ignore:distutils Version classes are deprecated. Use packaging.version instead.:DeprecationWarning:prance
+  ignore:'session_cookie_name' is deprecated and will be removed in Flask 2.3. Use 'SESSION_COOKIE_NAME' in 'app.config' instead.:DeprecationWarning:flask_session
+
+  ignore:'_request_ctx_stack' is deprecated and will be removed in Flask 2.3.:DeprecationWarning:connexion
+  ignore:'app.json_encoder' is deprecated and will be removed in Flask 2.3. Customize 'app.json_provider_class' or 'app.json' instead.:DeprecationWarning:connexion
+
+  # these two below are actully caused by connexion but register as flask because connexion hands off to flask; we should remove this when connexion is upgraded
+  ignore:Setting 'json_encoder' on the app or a blueprint is deprecated and will be removed in Flask 2.3. Customize 'app.json' instead.:DeprecationWarning:flask
+  ignore:'JSONEncoder' is deprecated and will be removed in Flask 2.3. Use 'Flask.json' to provide an alternate JSON implementation instead.:DeprecationWarning:flask

--- a/pytest.ini
+++ b/pytest.ini
@@ -17,3 +17,6 @@ rp_ignore_errors = True
 rp_hierarchy_dirs = True
 rp_hierarchy_module = False
 rp_hierarchy_class = False
+
+filterwarnings =
+  error

--- a/tests/test_signout.py
+++ b/tests/test_signout.py
@@ -242,7 +242,7 @@ class TestSignout:
 
         response = flask_test_client.get(endpoint)
 
-        page_html = BeautifulSoup(response.data)
+        page_html = BeautifulSoup(response.data, "html.parser")
         assert response.status_code == 200
         assert "Test Application" in str(page_html)
 
@@ -260,7 +260,7 @@ class TestSignout:
 
         response = flask_test_client.get(endpoint)
 
-        page_html = BeautifulSoup(response.data)
+        page_html = BeautifulSoup(response.data, "html.parser")
         assert response.status_code == 200
         assert "Access Funding" in str(page_html)
 

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -1,3 +1,4 @@
+import pytest
 from flask import session
 from fsd_utils.authentication.utils import validate_token_rs256
 from testing.mocks.mocks.msal import ConfidentialClientApplication
@@ -78,6 +79,7 @@ def test_sso_logout_redirect_contains_return_app(flask_test_client, mock_redis_s
     assert response.location.endswith(expected_post_logout_redirect) is True
 
 
+@pytest.mark.filterwarnings("ignore:Value Error on get_token route:UserWarning")
 def test_sso_get_token_returns_404(flask_test_client):
     """
     GIVEN We have a functioning Authenticator API
@@ -85,6 +87,7 @@ def test_sso_get_token_returns_404(flask_test_client):
     THEN we should receive a 404 "No valid token" message
     """
     endpoint = "/sso/get-token"
+
     response = flask_test_client.get(endpoint)
 
     assert response.status_code == 404


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FPASF-491

### Change description
Turns all warnings into errors so that they can be caught early and developers are required to handle them (either by fixing the code or explicitly ignoring the error).

This ignores a few errors from our dependencies, and fixes others, such as:

* `logger.warn` being deprecated in favour of `logger.warning`
* setting the parser explicitly for `BeautifulSoup`
* removing some no-longer-used settings from `pytest.ini` (we seemingly don't use pytest-reportportal any more)
* declaring a pytest marker in `pytest.ini` (new_account)