### PR TITLE
FS-4546 post signout logout

### DIFF
--- a/api/session/auth_session.py
+++ b/api/session/auth_session.py
@@ -46,8 +46,9 @@ class AuthSessionView(MethodView):
                 error_response(404, "Session token expired or invalid")
         error_response(404, "No session token found")
 
+    # Deprecation warning (Use clear_session_post instead)
     @staticmethod
-    def clear_session():
+    def clear_session_get():
         """
         GET /sessions/sign-out endpoint
         Clears the user session (signing them out)
@@ -91,6 +92,76 @@ class AuthSessionView(MethodView):
 
         redirect_route = "magic_links_bp.signed_out"  # TODO: Remove defaulting to Magic Links, instead use return_app
         if return_app := request.args.get("return_app"):
+            if safe_app := Config.SAFE_RETURN_APPS.get(return_app):
+                redirect_route = safe_app.logout_endpoint
+                current_app.logger.info(f"Returning to {return_app} using {redirect_route}")
+            else:
+                current_app.logger.warning(f"{return_app} not listed as a safe app.")
+                abort(400, "Unknown return app.")
+
+        # Clear the cookie and redirect to signed out page
+        signed_out_url = url_for(
+            redirect_route,
+            status=status,
+            fund=fund_short_name,
+            round=round_short_name,
+            return_app=return_app,
+            return_path=return_path,
+        )
+        response = make_response(redirect(signed_out_url), 302)
+        response.set_cookie(
+            Config.FSD_USER_TOKEN_COOKIE_NAME,
+            "",
+            domain=Config.COOKIE_DOMAIN,
+            expires=0,
+        )
+        return response
+
+    @staticmethod
+    def clear_session_post():
+        """
+        POST /sessions/sign-out endpoint
+        Clears the user session (signing them out)
+        Also deletes an existing jwt auth cookie and removes the corresponding
+        link records from redis
+
+        Returns: 302 redirect to signed-out page
+        """
+        return_path = request.form.get("return_path")
+        fund_short_name = None
+        round_short_name = None
+        existing_auth_token = request.cookies.get(Config.FSD_USER_TOKEN_COOKIE_NAME)
+        existing_fund_round_token = request.cookies.get(Config.FSD_FUND_AND_ROUND_COOKIE_NAME)
+        status = "no_token"
+        valid_token = False
+        if existing_fund_round_token:
+            fund_round_token = validate_token(existing_fund_round_token)
+            fund_short_name = fund_round_token.get("fund")
+            round_short_name = fund_round_token.get("round")
+
+        if existing_auth_token:
+            # Check if token is valid
+            try:
+                valid_token = validate_token(existing_auth_token)
+                status = "sign_out_request"
+            except jwt.ExpiredSignatureError:
+                valid_token = decode_with_options(existing_auth_token, options={"verify_exp": False})
+                status = "expired_token"
+            except jwt.PyJWTError as e:
+                current_app.logger.warning(f"PyJWTError: {e.__class__.__name__} - {e}")
+                status = "invalid_token"
+
+            # If validly issued token: create query params for signout url,
+            # and clear the redis store of the account and link record
+            if valid_token and isinstance(valid_token, dict):
+                MagicLinkMethods().clear_existing_user_record(valid_token.get("accountId"))
+
+        # Clear the session
+        session.clear()
+        clear_sentry()
+
+        redirect_route = "magic_links_bp.signed_out"  # TODO: Remove defaulting to Magic Links, instead use return_app
+        if return_app := request.form.get("return_app"):
             if safe_app := Config.SAFE_RETURN_APPS.get(return_app):
                 redirect_route = safe_app.logout_endpoint
                 current_app.logger.info(f"Returning to {return_app} using {redirect_route}")

--- a/api/session/auth_session.py
+++ b/api/session/auth_session.py
@@ -48,7 +48,7 @@ class AuthSessionView(MethodView):
 
     def clear_session(return_app=None, return_path=None):
         """
-        GET /sessions/sign-out endpoint
+        /sessions/sign-out endpoint
         Clears the user session (signing them out)
         Also deletes an existing jwt auth cookie and removes the corresponding
         link records from redis

--- a/api/session/auth_session.py
+++ b/api/session/auth_session.py
@@ -48,7 +48,6 @@ class AuthSessionView(MethodView):
 
     def clear_session(return_app=None, return_path=None):
         """
-        /sessions/sign-out endpoint
         Clears the user session (signing them out)
         Also deletes an existing jwt auth cookie and removes the corresponding
         link records from redis
@@ -117,12 +116,14 @@ class AuthSessionView(MethodView):
     # Deprecation warning (Use clear_session_post instead)
     @staticmethod
     def clear_session_get():
+        """GET /sessions/sign-out endpoint"""
         return_app = request.args.get("return_app")
         return_path = request.args.get("return_path")
         return AuthSessionView.clear_session(return_app, return_path)
 
     @staticmethod
     def clear_session_post():
+        """POST /sessions/sign-out endpoint"""
         return_app = request.form.get("return_app")
         return_path = request.form.get("return_path")
         return AuthSessionView.clear_session(return_app, return_path)

--- a/api/sso/routes.py
+++ b/api/sso/routes.py
@@ -33,64 +33,53 @@ class SsoView(MethodView):
 
         return redirect(session["flow"]["auth_uri"]), 302
 
-    # Deprecation warning (Use logout_getPost instead)
-    def logout_get(self):
+    def logout(post_logout_redirect_uri=None):
         """
-        GET /sso/logout endpoint
+        /sso/logout endpoint
         Clears the user session then redirects to
         Azure AD logout endpoint to logout from our tenants web session too
         :return:
         """
+        azure_ad_sign_out_url = (
+            Config.AZURE_AD_AUTHORITY
+            + "/oauth2/v2.0/logout"
+            + ("?post_logout_redirect_uri=" + post_logout_redirect_uri if post_logout_redirect_uri else "")
+        )
+
+        # Clear session
+        session.clear()
+        response = make_response(redirect(azure_ad_sign_out_url), 302)
+
+        # Clear the JWT cookie
+        response.set_cookie(
+            Config.FSD_USER_TOKEN_COOKIE_NAME,
+            "",
+            domain=Config.COOKIE_DOMAIN,
+            expires=0,
+        )
+
+        # Clear any additional session state (e.g., Sentry)
+        clear_sentry()
+        return response
+
+    # Deprecation warning (Use logout_post instead)
+    def logout_get(self):
         post_logout_redirect_uri = request.args.get(
             "post_logout_redirect_uri",
             Config.SSO_POST_SIGN_OUT_URL + f"?{urlencode({'return_app': session['return_app']})}"
             if "return_app" in session
             else "",
         )
-        azure_ad_sign_out_url = (
-            Config.AZURE_AD_AUTHORITY
-            + "/oauth2/v2.0/logout"
-            + ("?post_logout_redirect_uri=" + post_logout_redirect_uri if post_logout_redirect_uri else "")
-        )
-        session.clear()
-        response = make_response(redirect(azure_ad_sign_out_url), 302)
-        response.set_cookie(
-            Config.FSD_USER_TOKEN_COOKIE_NAME,
-            "",
-            domain=Config.COOKIE_DOMAIN,
-            expires=0,
-        )
-        clear_sentry()
-        return response
+        return SsoView.logout(post_logout_redirect_uri)
 
     def logout_post(self):
-        """
-        POST /sso/logout endpoint
-        Clears the user session then redirects to
-        Azure AD logout endpoint to logout from our tenants web session too
-        :return:
-        """
         post_logout_redirect_uri = request.form.get(
             "post_logout_redirect_uri",
             Config.SSO_POST_SIGN_OUT_URL + f"?{urlencode({'return_app': session['return_app']})}"
             if "return_app" in session
             else "",
         )
-        azure_ad_sign_out_url = (
-            Config.AZURE_AD_AUTHORITY
-            + "/oauth2/v2.0/logout"
-            + ("?post_logout_redirect_uri=" + post_logout_redirect_uri if post_logout_redirect_uri else "")
-        )
-        session.clear()
-        response = make_response(redirect(azure_ad_sign_out_url), 302)
-        response.set_cookie(
-            Config.FSD_USER_TOKEN_COOKIE_NAME,
-            "",
-            domain=Config.COOKIE_DOMAIN,
-            expires=0,
-        )
-        clear_sentry()
-        return response
+        return SsoView.logout(post_logout_redirect_uri)
 
     def get_token(self):
         """

--- a/api/sso/routes.py
+++ b/api/sso/routes.py
@@ -35,7 +35,6 @@ class SsoView(MethodView):
 
     def logout(post_logout_redirect_uri=None):
         """
-        /sso/logout endpoint
         Clears the user session then redirects to
         Azure AD logout endpoint to logout from our tenants web session too
         :return:
@@ -64,6 +63,7 @@ class SsoView(MethodView):
 
     # Deprecation warning (Use logout_post instead)
     def logout_get(self):
+        """GET /sso/logout endpoint"""
         post_logout_redirect_uri = request.args.get(
             "post_logout_redirect_uri",
             Config.SSO_POST_SIGN_OUT_URL + f"?{urlencode({'return_app': session['return_app']})}"
@@ -73,6 +73,7 @@ class SsoView(MethodView):
         return SsoView.logout(post_logout_redirect_uri)
 
     def logout_post(self):
+        """POST /sso/logout endpoint"""
         post_logout_redirect_uri = request.form.get(
             "post_logout_redirect_uri",
             Config.SSO_POST_SIGN_OUT_URL + f"?{urlencode({'return_app': session['return_app']})}"

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -40,7 +40,7 @@ class DefaultConfig(object):
     # Hostname for this service
     AUTHENTICATOR_HOST = environ.get("AUTHENTICATOR_HOST", "")
     NEW_LINK_ENDPOINT = "/service/magic-links/new"
-    SSO_LOGOUT_ENDPOINT = "api_sso_routes_SsoView_logout"
+    SSO_LOGOUT_ENDPOINT = "api_sso_routes_SsoView_logout_get"
     SSO_LOGIN_ENDPOINT = "api_sso_routes_SsoView_login"
     SSO_POST_SIGN_OUT_URL = AUTHENTICATOR_HOST + "/service/sso/signed-out/signout-request"
 

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -75,7 +75,16 @@ paths:
         - sso
       summary: Microsoft Authentication Library Logout redirect
       description: Redirect to Microsoft Authentication Logout Flow
-      operationId: api.sso.routes.SsoView.logout
+      operationId: api.sso.routes.SsoView.logout_get
+      responses:
+        302:
+          description: SUCCESS - Redirect to Microsoft Authentication Logout Flow
+    post:
+      tags:
+        - sso
+      summary: Microsoft Authentication Library Logout redirect
+      description: Redirect to Microsoft Authentication Logout Flow
+      operationId: api.sso.routes.SsoView.logout_post
       responses:
         302:
           description: SUCCESS - Redirect to Microsoft Authentication Logout Flow
@@ -117,7 +126,7 @@ paths:
         - sessions
       summary: Signs out a user
       description: Signs out a user who has authenticated via a magic link
-      operationId: api.AuthSessionView.clear_session
+      operationId: api.AuthSessionView.clear_session_get
       parameters:
         - in: query
           name: return_app
@@ -125,6 +134,29 @@ paths:
           required: false
           schema:
             type: string
+      responses:
+        302:
+          description: SUCCESS - Active user session cleared and redirected to the signed out page
+    post:
+      tags:
+        - sessions
+      summary: Signs out a user
+      description: Signs out a user who has authenticated via a magic link
+      operationId: api.AuthSessionView.clear_session_post
+      requestBody:
+        description: The return app and return path
+        required: false
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                return_app:
+                  type: string
+                  description: Optional parameter to specify the return app
+                return_path:
+                  type: string
+                  description: Optional parameter to specify the return path
       responses:
         302:
           description: SUCCESS - Active user session cleared and redirected to the signed out page


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-4546

### Change description
- POST requests created for logout and sign-out endpoints
- Consolidated shared logic for sessions/logout post and get endpoint in clear_session function.
- Updated `clear_session_get` and `clear_session_post` methods to call the unified `clear_session` function.
- Consolidated shared logic into a single 'logout' function.
- Updated `logout_get` and `logout_post` methods to call the unified `logout` function.

- [X] Unit tests and other appropriate tests added or updated
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- Login to frontend and assessment and verify /sessions/sign-out and /sso/logout are logging user out as expected


### Screenshots of UI changes (if applicable)
Assessment Logout:
<img width="1432" alt="Screenshot 2024-09-09 at 16 18 11" src="https://github.com/user-attachments/assets/36b213c4-fd1b-4205-a8d6-d71015ef7e92">


<img width="1479" alt="Screenshot 2024-09-09 at 16 19 14" src="https://github.com/user-attachments/assets/fd5fd2ad-a190-426e-837b-bfdbb6ea41e7">

Application signout:
<img width="1418" alt="Screenshot 2024-09-09 at 16 20 21" src="https://github.com/user-attachments/assets/4777cb11-384c-4ae3-bbf3-5e5d30ea913a">


<img width="1451" alt="Screenshot 2024-09-09 at 16 20 45" src="https://github.com/user-attachments/assets/4fd9389b-f23a-434e-aa3e-714284365e7c">
