### PR TITLE
Update COF support email from levellingup domain to communities

### DIFF
--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -26,7 +26,7 @@ class DefaultConfig(object):
 
     FLASK_ROOT = str(Path(__file__).parent.parent.parent)
     FLASK_ENV = environ.get("FLASK_ENV")
-    SUPPORT_MAILBOX_EMAIL = "fsd.support@levellingup.gov.uk"
+    SUPPORT_MAILBOX_EMAIL = "fundingservice.support@communities.gov.uk"
 
     # Logging
     FSD_LOG_LEVEL = logging.WARNING

--- a/tests/api_data/get_endpoint_data.json
+++ b/tests/api_data/get_endpoint_data.json
@@ -101,7 +101,7 @@
         "assessment_deadline": "2023-03-20 00:00:01",
         "contact_details": {
             "phone": "",
-            "email_address": "COF@levellingup.gov.uk",
+            "email_address": "COF@communities.gov.uk",
             "text_phone": ""
         },
         "support_availability": {
@@ -135,7 +135,7 @@
         "assessment_deadline": "2023-03-20T00:00:01",
         "contact_details": {
             "phone": "",
-            "email_address": "COF@levellingup.gov.uk",
+            "email_address": "COF@communities.gov.uk",
             "text_phone": ""
         },
         "support_availability": {


### PR DESCRIPTION

### Change description
The old COF support email was using the levellingup domain ( [cof@levellingup.gov.uk](mailto:cof@levellingup.gov.uk) ). This has been updated to the communities domain ( [cof@communities.gov.uk](mailto:cof@communities.gov.uk) )

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
