### PR TITLE
BAU: log error in case of get-token failure but display generic 500 page

### DIFF
--- a/api/sso/routes.py
+++ b/api/sso/routes.py
@@ -99,7 +99,7 @@ class SsoView(MethodView):
                 session.get("flow", {}), request.args
             )
             if "error" in result:
-                return result, 500
+                return abort(500, "Azure AD get-token flow failed with: {}".format(result))
             session["user"] = result.get("id_token_claims")
             self._save_cache(cache)
         except ValueError as e:  # Usually caused by CSRF

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -182,6 +182,19 @@ def test_sso_get_token_prevents_overwrite_of_existing_azure_subject_id(flask_tes
     )
 
 
+def test_sso_get_token_500_when_error_in_auth_code_flow(flask_test_client, mocker, caplog):
+    mock_build_msal_app = mocker.patch("api.sso.routes.SsoView._build_msal_app")
+    mock_msal_app = mock_build_msal_app.return_value
+    mock_msal_app.acquire_token_by_auth_code_flow.return_value = {"error": "some_error"}
+
+    endpoint = "/sso/get-token"
+    response = flask_test_client.get(endpoint)
+
+    assert response.status_code == 500
+    assert "get-token flow failed with: {'error': 'some_error'}" in caplog.text
+    assert "some_error" not in response.text
+
+
 def test_sso_get_token_logs_error_for_roleless_users(flask_test_client, mocker, caplog):
     """
     GIVEN We have a functioning Authenticator API


### PR DESCRIPTION
### Change description
Previously we were displaying the error from Azure AD error back to the user (I guess for developer convenience but this is not best practice security wise) this changes it to log the error internally and display a generic 500 message

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Make secret key invalid locally, 500 page should display and error should be logged in console.


### Screenshots of UI changes (if applicable)
