### PR TITLE
Add .python-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,9 +79,6 @@ target/
 profile_default/
 ipython_config.py
 
-# pyenv
-.python-version
-
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies


### PR DESCRIPTION
### Change description
Adds a `.python-version` file that can be read by `pyenv` or `uv` when creating virtual environments. Should simplify setup, where the docker-runner's `install-venv-all-repos.sh` script can sometimes pick the wrong python if you have multiple installed.