### PR TITLE
Upgrade pre-commit

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -5,7 +5,7 @@ black
 debugpy
 deepdiff
 invoke
-pre-commit
+pre-commit~=4.0.0
 pytest
 pytest-env
 pytest-flask

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -171,9 +171,7 @@ funding-service-design-utils==5.1.1
 govuk-frontend-jinja==2.3.0
     # via -r requirements.txt
 greenlet==3.1.1
-    # via
-    #   -r requirements.txt
-    #   sqlalchemy
+    # via -r requirements.txt
 gunicorn==20.1.0
     # via
     #   -r requirements.txt
@@ -275,7 +273,7 @@ pluggy==1.0.0
     # via pytest
 prance==0.21.8.0
     # via -r requirements.txt
-pre-commit==2.19.0
+pre-commit==4.0.1
     # via -r requirements-dev.in
 py==1.11.0
     # via pytest
@@ -445,8 +443,6 @@ swagger-ui-bundle==0.0.9
     # via -r requirements-dev.in
 tenacity==6.3.1
     # via pytest-selenium
-toml==0.10.2
-    # via pre-commit
 tomli==2.0.1
     # via
     #   black


### PR DESCRIPTION
### Change description
Bumps our local pre-commit version to be >=4.0. This matches what runs in pre-commit.ci, so is best to keep roughly in sync.

In particular this bump has been prompted by CI failures on the assessment-store, where one of the installed hooks is incompatible with v4 of pre-commit because the `python_venv` "language" has been removed. We don't see this issue locally on that repo because we're still running an older version of pre-commmit.