### PR TITLE
Delete .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*   @communitiesuk/fsd-pre-award-deployers @communitiesuk/fsd-post-award-deployers


### PR DESCRIPTION
We are no longer enforcing approvals from both teams as this no longer makes sense following team re-structure.

### Change description
This is no longer logical following team changes

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Any 2 people should be able to approve following merge of this change.

### Screenshots of UI changes (if applicable)
