### PR TITLE
BAU: Remove recreate deploy strategy on test

### DIFF
--- a/copilot/fsd-authenticator/manifest.yml
+++ b/copilot/fsd-authenticator/manifest.yml
@@ -81,8 +81,6 @@ environments:
     count:
       spot: 1
   test:
-    deployment:
-      rolling: 'recreate'
     variables:
       ALLOW_ASSESSMENT_LOGIN_VIA_MAGIC_LINK: true
     count:


### PR DESCRIPTION
### Change description
Remove recreate deploy strategy on test, as this causes downtime during deployment e.g. https://communities-govuk.slack.com/archives/C0478PGHL1E/p1730369264494489?thread_ts=1730094584.136009&cid=C0478PGHL1E

This will revert to the default as described here: https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#deployment

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Should deploy without downtime on test


### Screenshots of UI changes (if applicable)
