### PR TITLE
FS-4805 - Add FAB and Form Designer to the list of safe return apps

### DIFF
--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -118,6 +118,12 @@ class DefaultConfig(object):
     # Post-award submit
     POST_AWARD_SUBMIT_HOST = environ.get("POST_AWARD_SUBMIT_HOST", "")
 
+    # Form Designer
+    FORM_DESIGNER_HOST = environ.get("FORM_DESIGNER_HOST", "")
+
+    # Fund Application Builder
+    FUND_APPLICATION_BUILDER_HOST = environ.get("FUND_APPLICATION_BUILDER_HOST", "")
+
     # Safe list of return applications
     SAFE_RETURN_APPS = {
         SupportedApp.POST_AWARD_FRONTEND.value: SafeAppConfig(
@@ -129,6 +135,16 @@ class DefaultConfig(object):
             login_url=urljoin(POST_AWARD_SUBMIT_HOST, "/"),
             logout_endpoint="sso_bp.signed_out",
             service_title="Submit monitoring and evaluation data",
+        ),
+        SupportedApp.FORM_DESIGNER.value: SafeAppConfig(
+            login_url=urljoin(FORM_DESIGNER_HOST, "/"),
+            logout_endpoint="sso_bp.signed_out",
+            service_title="Form Designer",
+        ),
+        SupportedApp.FUND_APPLICATION_BUILDER.value: SafeAppConfig(
+            login_url=urljoin(FUND_APPLICATION_BUILDER_HOST, "/"),
+            logout_endpoint="sso_bp.signed_out",
+            service_title="Fund Application Builder",
         ),
     }
 

--- a/copilot/fsd-authenticator/manifest.yml
+++ b/copilot/fsd-authenticator/manifest.yml
@@ -52,6 +52,8 @@ variables:
   POST_AWARD_SUBMIT_HOST: "https://submit-monitoring-data.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
   APPLICANT_FRONTEND_HOST: "https://frontend.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
   ASSESSMENT_FRONTEND_HOST: "https://assessment.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
+  FORM_DESIGNER_HOST: "https://form-designer.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
+  FUND_APPLICATION_BUILDER_HOST: "https://fund-application-builder.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
   FLASK_ENV: "${COPILOT_ENVIRONMENT_NAME}"
   COOKIE_DOMAIN: ".test.levellingup.gov.uk"
   ALLOW_ASSESSMENT_LOGIN_VIA_MAGIC_LINK: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "flask-talisman==0.8.1",
     "flask-wtf==1.2.2",
     "flask==2.2.5",
-    "funding-service-design-utils==5.1.8",
+    "funding-service-design-utils==5.2.0",
     "govuk-frontend-jinja==2.3.0",
     "greenlet==3.1.1",
     "jsmin==3.0.1",

--- a/uv.lock
+++ b/uv.lock
@@ -648,7 +648,7 @@ requires-dist = [
     { name = "flask-session", specifier = "==0.4.0" },
     { name = "flask-talisman", specifier = "==0.8.1" },
     { name = "flask-wtf", specifier = "==1.2.2" },
-    { name = "funding-service-design-utils", specifier = "==5.1.8" },
+    { name = "funding-service-design-utils", specifier = "==5.2.0" },
     { name = "govuk-frontend-jinja", specifier = "==2.3.0" },
     { name = "greenlet", specifier = "==3.1.1" },
     { name = "jsmin", specifier = "==3.0.1" },
@@ -682,7 +682,7 @@ dev = [
 
 [[package]]
 name = "funding-service-design-utils"
-version = "5.1.8"
+version = "5.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -703,9 +703,9 @@ dependencies = [
     { name = "sentry-sdk", extra = ["flask"] },
     { name = "sqlalchemy-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b4/dd/4f7add7b4783b036bbfc1a1cfb08d5b5a9b2ee0188ea6b1181278acf6151/funding_service_design_utils-5.1.8.tar.gz", hash = "sha256:faa0c6801a0e7ccd8ced7e96f64fb89e2d5fe50bb6304771209cff236e2e4276", size = 66914 }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/f6/683e686a975db8074930e7c65203fafbe5e18c460e385e1072eae884301f/funding_service_design_utils-5.2.0.tar.gz", hash = "sha256:06bccd7814647ff1ee226eeaf323aaa1c284188bc03bbfdaa313ca0f0b8898ba", size = 67461 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/30/6c2d7ad27dd2487ad6d9b2fb968405519e90a2d99db9b54d7591d2f3493a/funding_service_design_utils-5.1.8-py3-none-any.whl", hash = "sha256:ba4374d09c5437dda0a6b2941447b1d4f90815d1d043014e65b04dbad41e9974", size = 80561 },
+    { url = "https://files.pythonhosted.org/packages/41/6b/a6c4dc52793049e7bf13432881997f822a1ba13c9f30c35dc07be0e51296/funding_service_design_utils-5.2.0-py3-none-any.whl", hash = "sha256:773d64ec9a06b6c73f057871a5a16b048e513bdee770d0b7f5d757610e801c38", size = 81221 },
 ]
 
 [[package]]


### PR DESCRIPTION
### Ticket

[Add authentication for FAB](https://mhclgdigital.atlassian.net/browse/FS-4805)

### Description

See ticket for wider context. This PR specifically is to add FAB to the list of safe return apps alongside the other frontend apps that use authentication - Submit and Find (Assess is handled in a bespoke way).

Form Designer is also added pre-emptively, to prevent the need for another PR when work on this ticket - [Add authentication for Form Designer](https://mhclgdigital.atlassian.net/browse/FS-4794) - begins.