### PR TITLE
FSPT-123: Trace all requests on pre-prod

### DIFF
--- a/copilot/fsd-authenticator/manifest.yml
+++ b/copilot/fsd-authenticator/manifest.yml
@@ -55,6 +55,7 @@ variables:
   FLASK_ENV: "${COPILOT_ENVIRONMENT_NAME}"
   COOKIE_DOMAIN: ".test.levellingup.gov.uk"
   ALLOW_ASSESSMENT_LOGIN_VIA_MAGIC_LINK: false
+  SENTRY_TRACES_SAMPLE_RATE: 1.0
   REDIS_INSTANCE_URI:
     from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-MagicLinksRedisInstanceURI
   AWS_MSG_BUCKET_NAME:
@@ -161,6 +162,7 @@ environments:
       POST_AWARD_FRONTEND_HOST: "https://find-monitoring-data.access-funding.levellingup.gov.uk"
       POST_AWARD_SUBMIT_HOST: "https://submit-monitoring-data.access-funding.levellingup.gov.uk"
       FLASK_ENV: production
+      SENTRY_TRACES_SAMPLE_RATE: 0.02
     count:
       range: 2-4
       cooldown:


### PR DESCRIPTION
### Change description
Trace all requests on pre-prod

The production value is based on utils default from: https://github.com/communitiesuk/funding-service-design-utils/blob/b65c285328847640f8622c368595938b60e44d02/fsd_utils/sentry/init_sentry.py#L19C59-L19C63 we could possibly increase this in future, but previously a combination of bot traffic and looping errors have used all our quota.


- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
More requests should be traced post-deployment


### Screenshots of UI changes (if applicable)
