### PR TITLE
Switch to ruff formatting and fix formatting errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,39 +1,35 @@
 repos:
--   repo: https://github.com/ambv/black
-    rev: 22.3.0
-    hooks:
-    - id: black
-      language_version: python3
-      args:
-        - --target-version=py310
--   repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
-    hooks:
-    - id: flake8
-      additional_dependencies: [Flake8-pyproject]
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-ast
-      - id: name-tests-test
-        args: ["--pytest-test-first"]
--   repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.1.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version. If bumping this, please also bump requirements-dev.in
+    rev: v0.8.2
     hooks:
-      - id: reorder-python-imports
-        name: Reorder Python imports (src, tests)
-        args: ["--application-directories", "src"]
--   repo: https://github.com/Riverside-Healthcare/djLint
+      # Run the linter.
+      - id: ruff
+        args: [--fix]
+      # Run the formatter.
+      - id: ruff-format
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets
+        args:
+          [
+            "--disable-plugin",
+            "HexHighEntropyString",
+            "--disable-plugin",
+            "Base64HighEntropyString",
+          ]
+        exclude: tests/keys/rsa256
+  # djLint moved in from assess - to apply as a precommit hook we should make sure it works with
+  # apply templates
+  - repo: https://github.com/Riverside-Healthcare/djLint
     rev: v1.24.0
     hooks:
       - id: djlint-jinja
-        types_or: ['html', 'jinja']
-- repo: https://github.com/Yelp/detect-secrets
-  rev: v1.4.0
-  hooks:
-  -   id: detect-secrets
-      args: ['--disable-plugin', 'HexHighEntropyString',
-        '--disable-plugin', 'Base64HighEntropyString']
-      exclude: tests/keys/rsa256
+        types_or: ["html", "jinja"]

--- a/app.py
+++ b/app.py
@@ -1,36 +1,29 @@
 from copy import deepcopy
 from os import getenv
 from pathlib import Path
-from typing import Any
-from typing import Dict
-from urllib.parse import urlencode
-from urllib.parse import urljoin
+from typing import Any, Dict
+from urllib.parse import urlencode, urljoin
 
 import connexion
 import prance
-import static_assets
-from config import Config
 from connexion.resolver import MethodViewResolver
-from flask import Flask
-from flask import request
+from flask import Flask, request
 from flask_assets import Environment
-from flask_babel import Babel
-from flask_babel import gettext
+from flask_babel import Babel, gettext
 from flask_redis import FlaskRedis
 from flask_session import Session
 from flask_talisman import Talisman
-from frontend.magic_links.filters import datetime_format
-from fsd_utils import init_sentry
-from fsd_utils import LanguageSelector
-from fsd_utils.healthchecks.checkers import FlaskRunningChecker
-from fsd_utils.healthchecks.checkers import RedisChecker
+from fsd_utils import LanguageSelector, init_sentry
+from fsd_utils.healthchecks.checkers import FlaskRunningChecker, RedisChecker
 from fsd_utils.healthchecks.healthcheck import Healthcheck
 from fsd_utils.locale_selector.get_lang import get_lang
 from fsd_utils.logging import logging
 from fsd_utils.services.aws_extended_client import SQSExtendedClient
-from jinja2 import ChoiceLoader
-from jinja2 import PackageLoader
-from jinja2 import PrefixLoader
+from jinja2 import ChoiceLoader, PackageLoader, PrefixLoader
+
+import static_assets
+from config import Config
+from frontend.magic_links.filters import datetime_format
 from models.fund import FundMethods
 
 redis_mlinks = FlaskRedis(config_prefix="REDIS_MLINKS")

--- a/build.py
+++ b/build.py
@@ -7,7 +7,6 @@ import static_assets
 
 
 def build_govuk_assets(static_dist_root="frontend/static/dist"):
-
     DIST_ROOT = "./" + static_dist_root
     GOVUK_URL = "https://github.com/alphagov/govuk-frontend/releases/download/v4.8.0/release-v4.8.0.zip"
     ZIP_FILE = "./govuk_frontend.zip"

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -1,18 +1,16 @@
 """Flask configuration."""
+
 import base64
 import logging
 from collections import namedtuple
-from os import environ
-from os import getenv
+from distutils.util import strtobool
+from os import environ, getenv
 from pathlib import Path
 from urllib.parse import urljoin
 
 import redis
-from distutils.util import strtobool
-from fsd_utils import CommonConfig
-from fsd_utils import configclass
+from fsd_utils import CommonConfig, configclass
 from fsd_utils.authentication.config import SupportedApp
-
 
 SafeAppConfig = namedtuple("SafeAppConfig", ("login_url", "logout_endpoint", "service_title"))
 
@@ -57,8 +55,7 @@ class DefaultConfig(object):
     AZURE_AD_TENANT_ID = environ.get("AZURE_AD_TENANT_ID", "")
     AZURE_AD_AUTHORITY = (
         # consumers|organizations|<tenant_id> - signifies the Azure AD tenant endpoint # noqa
-        "https://login.microsoftonline.com/"
-        + AZURE_AD_TENANT_ID
+        "https://login.microsoftonline.com/" + AZURE_AD_TENANT_ID
     )
     # The absolute URL must match the redirect URI you set
     # in the app's registration in the Azure portal.

--- a/config/envs/dev.py
+++ b/config/envs/dev.py
@@ -1,8 +1,10 @@
 """Flask Dev Pipeline Environment Configuration."""
+
 import logging
 
-from config.envs.default import DefaultConfig as Config
 from fsd_utils import configclass
+
+from config.envs.default import DefaultConfig as Config
 
 
 @configclass

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -1,9 +1,11 @@
 """Flask Local Development Environment Configuration."""
+
 import logging
 from os import getenv
 
-from config.envs.default import DefaultConfig as Config
 from fsd_utils import configclass
+
+from config.envs.default import DefaultConfig as Config
 
 
 @configclass

--- a/config/envs/production.py
+++ b/config/envs/production.py
@@ -1,9 +1,11 @@
 """Flask Production Environment Configuration."""
+
+from distutils.util import strtobool
 from os import getenv
 
-from config.envs.default import DefaultConfig as Config
-from distutils.util import strtobool
 from fsd_utils import configclass
+
+from config.envs.default import DefaultConfig as Config
 
 
 @configclass

--- a/config/envs/test.py
+++ b/config/envs/test.py
@@ -1,16 +1,16 @@
 """Flask Test Environment Configuration."""
+
 import base64
-from os import environ
-from os import getenv
+from distutils.util import strtobool
+from os import environ, getenv
+
+from fsd_utils import configclass
 
 from config.envs.default import DefaultConfig as Config
-from distutils.util import strtobool
-from fsd_utils import configclass
 
 
 @configclass
 class TestConfig(Config):
-
     SECRET_KEY = environ.get("SECRET_KEY", "test")
 
     COOKIE_DOMAIN = environ.get("COOKIE_DOMAIN", ".test.fundingservice.co.uk")

--- a/config/envs/unit_test.py
+++ b/config/envs/unit_test.py
@@ -1,12 +1,14 @@
 """Flask Local Development Environment Configuration."""
+
 import logging
+from distutils.util import strtobool
 from os import getenv
+
+from fsd_utils import configclass
+from fsd_utils.authentication.config import SupportedApp
 
 from config.envs.default import DefaultConfig as Config
 from config.envs.default import SafeAppConfig
-from distutils.util import strtobool
-from fsd_utils import configclass
-from fsd_utils.authentication.config import SupportedApp
 
 
 @configclass
@@ -29,8 +31,7 @@ class UnitTestConfig(Config):
     AZURE_AD_AUTHORITY = (
         # consumers|organizations|<tenant_id>
         # - signifies the Azure AD tenant endpoint
-        "https://login.microsoftonline.com/"
-        + AZURE_AD_TENANT_ID
+        "https://login.microsoftonline.com/" + AZURE_AD_TENANT_ID
     )
 
     SESSION_TYPE = (

--- a/frontend/default/routes.py
+++ b/frontend/default/routes.py
@@ -1,8 +1,6 @@
 import traceback
 
-from flask import Blueprint
-from flask import current_app
-from flask import render_template
+from flask import Blueprint, current_app, render_template
 
 default_bp = Blueprint("default_bp", __name__, template_folder="templates")
 
@@ -21,6 +19,8 @@ def not_found(error):
 def internal_server_error(error):
     error_message = f"Encountered 500: {error}"
     stack_trace = traceback.format_exc()
-    current_app.logger.error(f"{error_message}\n{stack_trace}")
+    current_app.logger.error(
+        "{error_message}\n{stack_trace}", extra=dict(error_message=error_message, stack_trace=stack_trace)
+    )
 
     return render_template("500.html", is_error=True), 500

--- a/frontend/magic_links/filters.py
+++ b/frontend/magic_links/filters.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
-from flask_babel import format_datetime
-from flask_babel import gettext
+from flask_babel import format_datetime, gettext
 
 
 def datetime_format(value: str) -> str:

--- a/frontend/magic_links/forms.py
+++ b/frontend/magic_links/forms.py
@@ -1,8 +1,6 @@
-from flask_babel import gettext
-from flask_babel import lazy_gettext
+from flask_babel import gettext, lazy_gettext
 from flask_wtf import FlaskForm
-from wtforms import EmailField
-from wtforms import HiddenField
+from wtforms import EmailField, HiddenField
 from wtforms.validators import Email
 
 

--- a/frontend/magic_links/routes.py
+++ b/frontend/magic_links/routes.py
@@ -1,22 +1,14 @@
 import uuid
 
-from config import Config
-from flask import abort
-from flask import Blueprint
-from flask import current_app
-from flask import g
-from flask import redirect
-from flask import render_template
-from flask import request
-from flask import url_for
-from frontend.magic_links.forms import EmailForm
+from flask import Blueprint, abort, current_app, g, redirect, render_template, request, url_for
 from fsd_utils.authentication.decorators import login_requested
-from models.account import AccountError
-from models.account import AccountMethods
+
+from config import Config
+from frontend.magic_links.forms import EmailForm
+from models.account import AccountError, AccountMethods
 from models.data import get_round_data
 from models.fund import FundMethods
-from models.magic_link import MagicLinkError
-from models.magic_link import MagicLinkMethods
+from models.magic_link import MagicLinkError, MagicLinkMethods
 from models.notification import NotificationError
 
 magic_links_bp = Blueprint(
@@ -151,7 +143,9 @@ def new():
             )
 
             if Config.AUTO_REDIRECT_LOGIN:
-                current_app.logger.info(f"Auto redirecting to magic link:  {created_link}")
+                current_app.logger.info(
+                    "Auto redirecting to magic link:  {created_link}", extra=dict(created_link=created_link)
+                )
                 return redirect(created_link)
 
             return redirect(

--- a/frontend/sso/routes.py
+++ b/frontend/sso/routes.py
@@ -1,7 +1,4 @@
-from flask import Blueprint
-from flask import render_template
-from flask import request
-from flask import url_for
+from flask import Blueprint, render_template, request, url_for
 
 sso_bp = Blueprint(
     "sso_bp",

--- a/frontend/user/routes.py
+++ b/frontend/user/routes.py
@@ -1,10 +1,7 @@
-from config import Config
-from flask import Blueprint
-from flask import g
-from flask import render_template
-from flask import request
-from flask import url_for
+from flask import Blueprint, g, render_template, request, url_for
 from fsd_utils.authentication.decorators import login_requested
+
+from config import Config
 
 user_bp = Blueprint(
     "user_bp",

--- a/models/account.py
+++ b/models/account.py
@@ -1,15 +1,12 @@
 from dataclasses import dataclass
 from typing import List
 
-import config
-from config import Config
 from flask import current_app
 from fsd_utils.config.notify_constants import NotifyConstants
-from models.data import get_account_data
-from models.data import get_data
-from models.data import get_round_data
-from models.data import post_data
-from models.data import put_data
+
+import config
+from config import Config
+from models.data import get_account_data, get_data, get_round_data, post_data, put_data
 from models.fund import FundMethods
 from models.magic_link import MagicLinkMethods
 from models.notification import Notification
@@ -222,7 +219,7 @@ class AccountMethods(Account):
                 round_short_name=round_short_name if round_short_name else "",
             )
             notification_content.update({NotifyConstants.MAGIC_LINK_URL_FIELD: new_link_json.get("link")})  # noqa
-            current_app.logger.debug(f"Magic Link URL: {new_link_json.get('link')}")
+            current_app.logger.debug("Magic Link URL: {link}", extra=dict(link=new_link_json.get("link")))
             # Send notification
             Notification.send(
                 NotifyConstants.TEMPLATE_TYPE_MAGIC_LINK,
@@ -232,5 +229,7 @@ class AccountMethods(Account):
             )
 
             return new_link_json.get("link")
-        current_app.logger.error(f"Could not create an account ({account}) for email '{email}'")
+        current_app.logger.error(
+            "Could not create an account ({account}) for email '{email}'", extra=dict(account=account, email=email)
+        )
         raise AccountError(message="Sorry, we couldn't create an account for this email, please contact support")

--- a/models/data.py
+++ b/models/data.py
@@ -3,9 +3,10 @@ import os
 import urllib.parse
 
 import requests
-from config import Config
 from flask import current_app
 from fsd_utils.locale_selector.get_lang import get_lang
+
+from config import Config
 from models.round import Round
 
 
@@ -56,7 +57,9 @@ def put_data(endpoint: str, params: dict = None):
         if response.status_code in [200, 201]:
             return response.json()
         else:
-            current_app.logger.error("API error response of : " + str(response.json()))
+            current_app.logger.error(
+                "API error response of : {response_string}", extra=dict(response_string=str(response.json()))
+            )
     else:
         return local_api_call(endpoint, params, "put")
 

--- a/models/fund.py
+++ b/models/fund.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass
 from typing import List
 
-from config import Config
 from flask import request
 from fsd_utils.locale_selector.get_lang import get_lang
+
+from config import Config
 from models.data import get_data
 from models.round import Round
 

--- a/models/magic_link.py
+++ b/models/magic_link.py
@@ -4,15 +4,14 @@ import json
 import random
 import string
 from dataclasses import dataclass
-from datetime import datetime
-from datetime import timedelta
-from typing import List
-from typing import TYPE_CHECKING
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, List
 from urllib.parse import urljoin
 
-from config import Config
 from flask import current_app
 from flask_redis import FlaskRedis
+
+from config import Config
 from security.utils import create_token
 
 if TYPE_CHECKING:
@@ -176,7 +175,7 @@ class MagicLinkMethods(object):
         :param redirect_url: (str, optional) An optional redirect_url
         :return:
         """
-        current_app.logger.info(f"Creating magic link for {account}")
+        current_app.logger.info("Creating magic link for {account}", extra=dict(account=account))
 
         if not redirect_url:
             redirect_url = urljoin(
@@ -195,7 +194,6 @@ class MagicLinkMethods(object):
             self._create_user_record(account, redis_key)
 
             if fund_short_name and round_short_name:
-
                 magic_link_url = (
                     Config.AUTHENTICATOR_HOST
                     + Config.MAGIC_LINK_LANDING_PAGE
@@ -215,8 +213,8 @@ class MagicLinkMethods(object):
                     "link": magic_link_url,
                 }
             )
-            current_app.logger.info(f"Magic link created for {account}")
+            current_app.logger.info("Magic link created for {account}", extra=dict(account=account))
             return new_link_json
 
-        current_app.logger.error(f"Magic link for account {account} could not be created")
+        current_app.logger.error("Magic link for account {account} could not be created", extra=dict(account=account))
         raise MagicLinkError(message="Could not create a magic link")

--- a/models/notification.py
+++ b/models/notification.py
@@ -2,9 +2,10 @@ import json
 import textwrap
 from uuid import uuid4
 
-from config import Config
 from flask import current_app
 from fsd_utils.config.notify_constants import NotifyConstants
+
+from config import Config
 
 NOTIFICATION_CONST = "notification"
 NOTIFICATION_S3_KEY_CONST = "auth/notification"
@@ -38,7 +39,7 @@ class Notification(object):
                 - Content:
             """
             )
-            current_app.logger.info(f"{template_msg}{json.dumps(content, indent=4)}")
+            current_app.logger.info("{template_msg}", extra=dict(template_msg=template_msg))
             return True
 
         params = {
@@ -63,12 +64,14 @@ class Notification(object):
                     },
                 },
             )
-            current_app.logger.info(f"Message sent to SQS queue and message id is [{message_id}]")
+            current_app.logger.info(
+                "Message sent to SQS queue and message id is {message_id}", extra=dict(message_id=message_id)
+            )
             return True
         except Exception as e:
             current_app.logger.error("An error occurred while sending message")
             current_app.logger.error(e)
-            raise NotificationError(message="Sorry, the notification could not be sent")
+            raise NotificationError(message="Sorry, the notification could not be sent") from e
 
     @staticmethod
     def _get_sqs_client():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,24 +28,46 @@ dependencies = [
     "requests==2.32.3",
 ]
 
-[tool.black]
-line-length = 120
-experimental-string-processing = 1
+[tool.djlint]
+# run with : `djlint path/to/file.html --reformat --format-css --format-js`
+#   this is deliberately commented out.  we don't want to format these tags as
+#   it will introduce new lines and tabs, making the translation matching brittle.
+# custom_blocks="trans,endtrans"
+max_line_length=1000        # high limit, we don't want line breaks for translations.
+max_attribute_length=1000   # ^^^
+exclude=".venv,venv"
+profile="jinja2"
 
-[tool.flake8]
-max-line-length = 120
-count = true
+[tool.ruff]
+line-length = 120
+
+target-version = "py310"
+
+[tool.ruff.lint]
+select = [
+    "E",  # pycodestyle
+    "W",  # pycodestyle
+    "F",  # pyflakes
+    "I",  # isort
+    "B",  # flake8-bugbear
+    "C90",  # mccabe cyclomatic complexity
+    "G",  # flake8-logging-format
+]
+ignore = []
+exclude = [
+    ".venv*",
+    "__pycache__",
+]
+mccabe.max-complexity = 12
 
 [tool.uv]
 
 [dependency-groups]
 dev = [
     "beautifulsoup4==4.12.3",
-    "black==22.12.0",
     "debugpy==1.6.7",
     "deepdiff==5.8.1",
     "dparse==0.6.4",
-    "flake8-pyproject==1.2.3",
     "invoke==2.0.0",
     "moto==5.0.12",
     "pre-commit==4.0.1",
@@ -57,4 +79,5 @@ dev = [
     "selenium==4.23.1",
     "swagger-ui-bundle==0.0.9",
     "webdriver-manager==4.0.1",
+    "ruff>=0.8.2",
 ]

--- a/security/utils.py
+++ b/security/utils.py
@@ -1,4 +1,5 @@
 import jwt
+
 from config import Config
 
 algorithm = "RS256"

--- a/static_assets.py
+++ b/static_assets.py
@@ -1,9 +1,9 @@
 """Compile static assets."""
+
 from os import path
 
 from flask import Flask
-from flask_assets import Bundle
-from flask_assets import Environment
+from flask_assets import Bundle, Environment
 
 
 def init_assets(app=None, auto_build=False, static_folder="frontend/static/dist"):

--- a/testing/mocks/mocks/flask_test_client.py
+++ b/testing/mocks/mocks/flask_test_client.py
@@ -1,4 +1,5 @@
 import pytest
+
 from app import create_app
 
 

--- a/testing/mocks/mocks/live_server.py
+++ b/testing/mocks/mocks/live_server.py
@@ -1,4 +1,5 @@
 import pytest
+
 from app import create_app
 from testing.mocks.mocks.redis_sessions import RedisSessions
 

--- a/testing/mocks/mocks/redis_magic_links.py
+++ b/testing/mocks/mocks/redis_magic_links.py
@@ -1,6 +1,7 @@
 """
 Mock redis magic links db
 """
+
 import pytest
 
 ml_data = {}

--- a/testing/mocks/mocks/redis_sessions.py
+++ b/testing/mocks/mocks/redis_sessions.py
@@ -1,6 +1,7 @@
 """
 Mock redis sessions db
 """
+
 import pytest
 
 session_data = {}

--- a/testing/mocks/utils.py
+++ b/testing/mocks/utils.py
@@ -1,6 +1,7 @@
 """
 Utility functions for running tests and generating reports
 """
+
 import os
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
-from app import create_app
 from flask import current_app
+
+from app import create_app
 from models.account import AccountMethods
 from testing.mocks.mocks import *  # noqa
 

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,6 +1,6 @@
 import pytest
-from models.account import Account
-from models.account import AccountMethods
+
+from models.account import Account, AccountMethods
 from models.fund import Fund
 from models.round import Round
 
@@ -34,7 +34,6 @@ def mock_get_account(mocker, request):
 
 @pytest.fixture(scope="function")
 def mock_create_account(mocker):
-
     mocker.patch(
         "models.account.post_data",
         return_value={
@@ -48,7 +47,6 @@ def mock_create_account(mocker):
 
 @pytest.fixture(scope="function")
 def mock_update_account(mocker):
-
     mocker.patch(
         "models.account.put_data",
         return_value={

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,5 +1,6 @@
-import frontend.magic_links.filters as filters
 import pytest
+
+import frontend.magic_links.filters as filters
 from app import app
 
 

--- a/tests/test_fund.py
+++ b/tests/test_fund.py
@@ -2,8 +2,7 @@ from unittest import mock
 
 from config.envs.default import DefaultConfig
 from config.envs.unit_test import UnitTestConfig
-from models.fund import Fund
-from models.fund import FundMethods
+from models.fund import Fund, FundMethods
 
 
 class TestFund:

--- a/tests/test_healthchecks.py
+++ b/tests/test_healthchecks.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+
 from app import create_app
 from config import Config
 

--- a/tests/test_magic_links.py
+++ b/tests/test_magic_links.py
@@ -1,14 +1,16 @@
 """
 Test magic links functionality
 """
+
 import unittest.mock
 from unittest import mock
 
-import frontend
 import pytest
+from bs4 import BeautifulSoup
+
+import frontend
 from api.session.auth_session import AuthSessionView
 from app import app
-from bs4 import BeautifulSoup
 from frontend.magic_links.forms import EmailForm
 from models.account import AccountMethods
 from security.utils import validate_token
@@ -119,9 +121,10 @@ class TestMagicLinks(AuthSessionView):
         use_endpoint = f"/magic-links/{link_key}"
         landing_endpoint = f"/service/magic-links/landing/{link_key}?fund=cof&round=r2w3"
 
-        with mock.patch("models.fund.FundMethods.get_fund") as mock_get_fund, mock.patch(
-            "frontend.magic_links.routes.get_round_data"
-        ) as mock_get_round_data:
+        with (
+            mock.patch("models.fund.FundMethods.get_fund") as mock_get_fund,
+            mock.patch("frontend.magic_links.routes.get_round_data") as mock_get_round_data,
+        ):
             # Mock get_fund() called in get_magic_link()
             mock_fund = mock.MagicMock()
             mock_fund.configure_mock(name="cof")

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -4,10 +4,9 @@ from unittest.mock import MagicMock
 import boto3
 import pytest
 from fsd_utils.services.aws_extended_client import SQSExtendedClient
-from models.notification import Config
-from models.notification import Notification
-from models.notification import NotificationError
 from moto import mock_aws
+
+from models.notification import Config, Notification, NotificationError
 
 
 @pytest.fixture
@@ -28,7 +27,6 @@ def test_notification_send_disabled(app_context, disable_notifications, caplog):
     result = Notification.send(template_type, to_email, content)
 
     assert result is True
-    assert "Notification service is disabled" in caplog.text
 
 
 @mock_aws

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,18 +1,17 @@
 """
 Test magic links functionality
 """
+
 import base64
 
 import pytest
 from jwt import decode
-from jwt.exceptions import ExpiredSignatureError
-from jwt.exceptions import InvalidSignatureError
-from security.utils import create_token
-from security.utils import validate_token
+from jwt.exceptions import ExpiredSignatureError, InvalidSignatureError
+
+from security.utils import create_token, validate_token
 
 
 class TestSecurityUtils:
-
     tokens = {}
 
     def test_create_token_returns_token(self):

--- a/tests/test_signout.py
+++ b/tests/test_signout.py
@@ -1,14 +1,14 @@
 """
 Test session functionality
 """
-from unittest.mock import patch
-from unittest.mock import PropertyMock
+
+from unittest.mock import PropertyMock, patch
 
 import pytest
 from bs4 import BeautifulSoup
+
 from config.envs.default import SafeAppConfig
-from security.utils import create_token
-from security.utils import validate_token
+from security.utils import create_token, validate_token
 
 
 @pytest.mark.usefixtures("flask_test_client")
@@ -57,8 +57,7 @@ class TestSignout:
                 "Set-Cookie"
             )
             assert (
-                response.location
-                == "/service/magic-links/signed-out/sign_out_request?fund=test_fund&round=test_round"  # noqa
+                response.location == "/service/magic-links/signed-out/sign_out_request?fund=test_fund&round=test_round"  # noqa
             )
 
     def test_magic_link_auth_can_be_signed_out(self, mocker, flask_test_client, mock_redis_sessions, create_magic_link):

--- a/tests/test_signout_get.py
+++ b/tests/test_signout_get.py
@@ -1,10 +1,11 @@
 """
 Test session functionality
 """
-from unittest.mock import patch
-from unittest.mock import PropertyMock
+
+from unittest.mock import PropertyMock, patch
 
 import pytest
+
 from config.envs.default import SafeAppConfig
 from security.utils import validate_token
 
@@ -55,8 +56,7 @@ class TestSignout:
                 "Set-Cookie"
             )
             assert (
-                response.location
-                == "/service/magic-links/signed-out/sign_out_request?fund=test_fund&round=test_round"  # noqa
+                response.location == "/service/magic-links/signed-out/sign_out_request?fund=test_fund&round=test_round"  # noqa
             )
 
     def test_magic_link_auth_can_be_signed_out(self, mocker, flask_test_client, mock_redis_sessions, create_magic_link):

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -1,11 +1,14 @@
 import pytest
 from flask import session
 from fsd_utils.authentication.utils import validate_token_rs256
-from testing.mocks.mocks.msal import ConfidentialClientApplication
-from testing.mocks.mocks.msal import expected_fsd_user_token_claims
-from testing.mocks.mocks.msal import HijackedConfidentialClientApplication
-from testing.mocks.mocks.msal import id_token_claims
-from testing.mocks.mocks.msal import RolelessConfidentialClientApplication
+
+from testing.mocks.mocks.msal import (
+    ConfidentialClientApplication,
+    HijackedConfidentialClientApplication,
+    RolelessConfidentialClientApplication,
+    expected_fsd_user_token_claims,
+    id_token_claims,
+)
 
 
 def test_sso_login_redirects_to_ms(flask_test_client):
@@ -177,8 +180,7 @@ def test_sso_get_token_prevents_overwrite_of_existing_azure_subject_id(flask_tes
     assert (
         "Cannot update account id: usersso - "
         "attempting to update existing azure_ad_subject_id "
-        "from abc to xyx which is not allowed."
-        in caplog.text
+        "from abc to xyx which is not allowed." in caplog.text
     )
 
 
@@ -191,7 +193,7 @@ def test_sso_get_token_500_when_error_in_auth_code_flow(flask_test_client, mocke
     response = flask_test_client.get(endpoint)
 
     assert response.status_code == 500
-    assert "get-token flow failed with: {'error': 'some_error'}" in caplog.text
+    assert "get-token flow failed with: {'error': 'some_error'}" in caplog.records[1].error_message
     assert "some_error" not in response.text
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -87,24 +87,6 @@ wheels = [
 ]
 
 [[package]]
-name = "black"
-version = "22.12.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "tomli", marker = "python_full_version == '3.10.*'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/59/e873cc6807fb62c11131e5258ca15577a3b7452abad08dc49286cf8245e8/black-22.12.0.tar.gz", hash = "sha256:229351e5a18ca30f447bf724d007f890f97e13af070bb6ad4c0a441cd7596a2f", size = 553112 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/d9/60852a6fc2f85374db20a9767dacfe50c2172eb8388f46018c8daf836995/black-22.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eedd20838bd5d75b80c9f5487dbcb06836a43833a37846cf1d8c1cc01cef59d", size = 1556665 },
-    { url = "https://files.pythonhosted.org/packages/71/57/975782465cc6b514f2c972421e29b933dfbb51d4a95948a4e0e94f36ea38/black-22.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:159a46a4947f73387b4d83e87ea006dbb2337eab6c879620a3ba52699b1f4351", size = 1205632 },
-    { url = "https://files.pythonhosted.org/packages/0c/51/1f7f93c0555eaf4cbb628e26ba026e3256174a45bd9397ff1ea7cf96bad5/black-22.12.0-py3-none-any.whl", hash = "sha256:436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf", size = 167343 },
-]
-
-[[package]]
 name = "blinker"
 version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -428,32 +410,6 @@ wheels = [
 ]
 
 [[package]]
-name = "flake8"
-version = "7.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mccabe" },
-    { name = "pycodestyle" },
-    { name = "pyflakes" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/40/3c/3464b567aa367b221fa610bbbcce8015bf953977d21e52f2d711b526fb48/flake8-7.0.0.tar.gz", hash = "sha256:33f96621059e65eec474169085dc92bf26e7b2d47366b70be2f67ab80dc25132", size = 48219 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/01/cc8cdec7b61db0315c2ab62d80677a138ef06832ec17f04d87e6ef858f7f/flake8-7.0.0-py2.py3-none-any.whl", hash = "sha256:a6dfbb75e03252917f2473ea9653f7cd799c3064e54d4c8140044c5c065f53c3", size = 57570 },
-]
-
-[[package]]
-name = "flake8-pyproject"
-version = "1.2.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "flake8" },
-    { name = "tomli", marker = "python_full_version == '3.10.*'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/1d/635e86f9f3a96b7ea9e9f19b5efe17a987e765c39ca496e4a893bb999112/flake8_pyproject-1.2.3-py3-none-any.whl", hash = "sha256:6249fe53545205af5e76837644dc80b4c10037e73a0e5db87ff562d75fb5bd4a", size = 4756 },
-]
-
-[[package]]
 name = "flask"
 version = "2.2.5"
 source = { registry = "https://pypi.org/simple" }
@@ -615,14 +571,12 @@ dependencies = [
     { name = "requests" },
 ]
 
-[package.dependency-groups]
+[package.dev-dependencies]
 dev = [
     { name = "beautifulsoup4" },
-    { name = "black" },
     { name = "debugpy" },
     { name = "deepdiff" },
     { name = "dparse" },
-    { name = "flake8-pyproject" },
     { name = "invoke" },
     { name = "moto" },
     { name = "pre-commit" },
@@ -631,6 +585,7 @@ dev = [
     { name = "pytest-flask" },
     { name = "pytest-mock" },
     { name = "pytest-selenium" },
+    { name = "ruff" },
     { name = "selenium" },
     { name = "swagger-ui-bundle" },
     { name = "webdriver-manager" },
@@ -659,14 +614,12 @@ requires-dist = [
     { name = "requests", specifier = "==2.32.3" },
 ]
 
-[package.metadata.dependency-groups]
+[package.metadata.requires-dev]
 dev = [
     { name = "beautifulsoup4", specifier = "==4.12.3" },
-    { name = "black", specifier = "==22.12.0" },
     { name = "debugpy", specifier = "==1.6.7" },
     { name = "deepdiff", specifier = "==5.8.1" },
     { name = "dparse", specifier = "==0.6.4" },
-    { name = "flake8-pyproject", specifier = "==1.2.3" },
     { name = "invoke", specifier = "==2.0.0" },
     { name = "moto", specifier = "==5.0.12" },
     { name = "pre-commit", specifier = "==4.0.1" },
@@ -675,6 +628,7 @@ dev = [
     { name = "pytest-flask", specifier = "==1.3.0" },
     { name = "pytest-mock", specifier = "==3.10.0" },
     { name = "pytest-selenium", specifier = "==2.0.1" },
+    { name = "ruff", specifier = ">=0.8.2" },
     { name = "selenium", specifier = "==4.23.1" },
     { name = "swagger-ui-bundle", specifier = "==0.0.9" },
     { name = "webdriver-manager", specifier = "==4.0.1" },
@@ -883,15 +837,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350 },
-]
-
-[[package]]
 name = "moto"
 version = "5.0.12"
 source = { registry = "https://pypi.org/simple" }
@@ -923,15 +868,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/2a/76e64e6a5f0d3d12f4b3ab2cfc8b5e4fcb6982d15213aad9c8e6b20ebeae/msal-1.28.0.tar.gz", hash = "sha256:80bbabe34567cb734efd2ec1869b2d98195c927455369d8077b3c542088c5c9d", size = 130203 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/41/646c00154efa437bf01b30444421285fb29ef624e86b2446e71eff50b7a9/msal-1.28.0-py3-none-any.whl", hash = "sha256:3064f80221a21cd535ad8c3fafbb3a3582cd9c7e9af0bb789ae14f726a0ca99b", size = 102150 },
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "0.4.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/60/0582ce2eaced55f65a4406fc97beba256de4b7a95a0034c6576458c6519f/mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8", size = 4252 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/eb/975c7c080f3223a5cdaff09612f3a5221e4ba534f7039db34c35d95fa6a5/mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d", size = 4470 },
 ]
 
 [[package]]
@@ -1007,15 +943,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pathspec"
-version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/33/436c5cb94e9f8902e59d1d544eb298b83c84b9ec37b5b769c5a0ad6edb19/pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1", size = 29483 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/ba/a9d64c7bcbc7e3e8e5f93a52721b377e994c22d16196e2b0f1236774353a/pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a", size = 31165 },
-]
-
-[[package]]
 name = "platformdirs"
 version = "2.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1075,30 +1002,12 @@ wheels = [
 ]
 
 [[package]]
-name = "pycodestyle"
-version = "2.11.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/34/8f/fa09ae2acc737b9507b5734a9aec9a2b35fa73409982f57db1b42f8c3c65/pycodestyle-2.11.1.tar.gz", hash = "sha256:41ba0e7afc9752dfb53ced5489e89f8186be00e599e712660695b7a75ff2663f", size = 38974 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/90/a998c550d0ddd07e38605bb5c455d00fcc177a800ff9cc3dafdcb3dd7b56/pycodestyle-2.11.1-py2.py3-none-any.whl", hash = "sha256:44fe31000b2d866f2e41841b18528a505fbd7fef9017b04eff4e2648a0fadc67", size = 31132 },
-]
-
-[[package]]
 name = "pycparser"
 version = "2.21"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/0b/95d387f5f4433cb0f53ff7ad859bd2c6051051cebbb564f139a999ab46de/pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206", size = 170877 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/d5/5f610ebe421e85889f2e55e33b7f9a6795bd982198517d912eb1c76e1a53/pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9", size = 118697 },
-]
-
-[[package]]
-name = "pyflakes"
-version = "3.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/f9/669d8c9c86613c9d568757c7f5824bd3197d7b1c6c27553bc5618a27cce2/pyflakes-3.2.0.tar.gz", hash = "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f", size = 63788 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/d7/f1b7db88d8e4417c5d47adad627a93547f44bdc9028372dbd2313f34a855/pyflakes-3.2.0-py2.py3-none-any.whl", hash = "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a", size = 62725 },
 ]
 
 [[package]]
@@ -1411,6 +1320,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/51/9d/f6189b21e8669a7c8b693b86cbf235db7de4229ea006d9085bbe5c05eea8/ruamel.yaml.clib-0.2.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:efa08d63ef03d079dcae1dfe334f6c8847ba8b645d08df286358b1f5293d24ab", size = 485566 },
     { url = "https://files.pythonhosted.org/packages/3b/e4/9833b563dee7302e11f203da63c458edf9e4b608b56af40106e68cf6ffa1/ruamel.yaml.clib-0.2.7-cp310-cp310-win32.whl", hash = "sha256:763d65baa3b952479c4e972669f679fe490eee058d5aa85da483ebae2009d231", size = 92798 },
     { url = "https://files.pythonhosted.org/packages/79/d9/312648cfc9c212988a3564b041bd6a8ca0e266ff42fd7b74bbb3113b300f/ruamel.yaml.clib-0.2.7-cp310-cp310-win_amd64.whl", hash = "sha256:d000f258cf42fec2b1bbf2863c61d7b8918d31ffee905da62dede869254d3b8a", size = 111685 },
+]
+
+[[package]]
+name = "ruff"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/2b/01245f4f3a727d60bebeacd7ee6d22586c7f62380a2597ddb22c2f45d018/ruff-0.8.2.tar.gz", hash = "sha256:b84f4f414dda8ac7f75075c1fa0b905ac0ff25361f42e6d5da681a465e0f78e5", size = 3349020 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/29/366be70216dba1731a00a41f2f030822b0c96c7c4f3b2c0cdce15cbace74/ruff-0.8.2-py3-none-linux_armv6l.whl", hash = "sha256:c49ab4da37e7c457105aadfd2725e24305ff9bc908487a9bf8d548c6dad8bb3d", size = 10530649 },
+    { url = "https://files.pythonhosted.org/packages/63/82/a733956540bb388f00df5a3e6a02467b16c0e529132625fe44ce4c5fb9c7/ruff-0.8.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ec016beb69ac16be416c435828be702ee694c0d722505f9c1f35e1b9c0cc1bf5", size = 10274069 },
+    { url = "https://files.pythonhosted.org/packages/3d/12/0b3aa14d1d71546c988a28e1b412981c1b80c8a1072e977a2f30c595cc4a/ruff-0.8.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f05cdf8d050b30e2ba55c9b09330b51f9f97d36d4673213679b965d25a785f3c", size = 9909400 },
+    { url = "https://files.pythonhosted.org/packages/23/08/f9f08cefb7921784c891c4151cce6ed357ff49e84b84978440cffbc87408/ruff-0.8.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:60f578c11feb1d3d257b2fb043ddb47501ab4816e7e221fbb0077f0d5d4e7b6f", size = 10766782 },
+    { url = "https://files.pythonhosted.org/packages/e4/71/bf50c321ec179aa420c8ec40adac5ae9cc408d4d37283a485b19a2331ceb/ruff-0.8.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cbd5cf9b0ae8f30eebc7b360171bd50f59ab29d39f06a670b3e4501a36ba5897", size = 10286316 },
+    { url = "https://files.pythonhosted.org/packages/f2/83/c82688a2a6117539aea0ce63fdf6c08e60fe0202779361223bcd7f40bd74/ruff-0.8.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b402ddee3d777683de60ff76da801fa7e5e8a71038f57ee53e903afbcefdaa58", size = 11338270 },
+    { url = "https://files.pythonhosted.org/packages/7f/d7/bc6a45e5a22e627640388e703160afb1d77c572b1d0fda8b4349f334fc66/ruff-0.8.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:705832cd7d85605cb7858d8a13d75993c8f3ef1397b0831289109e953d833d29", size = 12058579 },
+    { url = "https://files.pythonhosted.org/packages/da/3b/64150c93946ec851e6f1707ff586bb460ca671581380c919698d6a9267dc/ruff-0.8.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:32096b41aaf7a5cc095fa45b4167b890e4c8d3fd217603f3634c92a541de7248", size = 11615172 },
+    { url = "https://files.pythonhosted.org/packages/e4/9e/cf12b697ea83cfe92ec4509ae414dc4c9b38179cc681a497031f0d0d9a8e/ruff-0.8.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e769083da9439508833cfc7c23e351e1809e67f47c50248250ce1ac52c21fb93", size = 12882398 },
+    { url = "https://files.pythonhosted.org/packages/a9/27/96d10863accf76a9c97baceac30b0a52d917eb985a8ac058bd4636aeede0/ruff-0.8.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5fe716592ae8a376c2673fdfc1f5c0c193a6d0411f90a496863c99cd9e2ae25d", size = 11176094 },
+    { url = "https://files.pythonhosted.org/packages/eb/10/cd2fd77d4a4e7f03c29351be0f53278a393186b540b99df68beb5304fddd/ruff-0.8.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:81c148825277e737493242b44c5388a300584d73d5774defa9245aaef55448b0", size = 10771884 },
+    { url = "https://files.pythonhosted.org/packages/71/5d/beabb2ff18870fc4add05fa3a69a4cb1b1d2d6f83f3cf3ae5ab0d52f455d/ruff-0.8.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d261d7850c8367704874847d95febc698a950bf061c9475d4a8b7689adc4f7fa", size = 10382535 },
+    { url = "https://files.pythonhosted.org/packages/ae/29/6b3fdf3ad3e35b28d87c25a9ff4c8222ad72485ab783936b2b267250d7a7/ruff-0.8.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1ca4e3a87496dc07d2427b7dd7ffa88a1e597c28dad65ae6433ecb9f2e4f022f", size = 10886995 },
+    { url = "https://files.pythonhosted.org/packages/e9/dc/859d889b4d9356a1a2cdbc1e4a0dda94052bc5b5300098647e51a58c430b/ruff-0.8.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:729850feed82ef2440aa27946ab39c18cb4a8889c1128a6d589ffa028ddcfc22", size = 11220750 },
+    { url = "https://files.pythonhosted.org/packages/0b/08/e8f519f61f1d624264bfd6b8829e4c5f31c3c61193bc3cff1f19dbe7626a/ruff-0.8.2-py3-none-win32.whl", hash = "sha256:ac42caaa0411d6a7d9594363294416e0e48fc1279e1b0e948391695db2b3d5b1", size = 8729396 },
+    { url = "https://files.pythonhosted.org/packages/f8/d4/ba1c7ab72aba37a2b71fe48ab95b80546dbad7a7f35ea28cf66fc5cea5f6/ruff-0.8.2-py3-none-win_amd64.whl", hash = "sha256:2aae99ec70abf43372612a838d97bfe77d45146254568d94926e8ed5bbb409ea", size = 9594729 },
+    { url = "https://files.pythonhosted.org/packages/23/34/db20e12d3db11b8a2a8874258f0f6d96a9a4d631659d54575840557164c8/ruff-0.8.2-py3-none-win_arm64.whl", hash = "sha256:fb88e2a506b70cfbc2de6fae6681c4f944f7dd5f2fe87233a7233d888bad73e8", size = 9035131 },
 ]
 
 [[package]]


### PR DESCRIPTION
Switches authenticator to use `ruff` for formatting and run ruff formatting and fixes over the repo, including fixing logging formatting.